### PR TITLE
Add Python automation guide and example scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+*.pyo

--- a/Basic_VXLAN_Configuration.md
+++ b/Basic_VXLAN_Configuration.md
@@ -1,0 +1,114 @@
+# Basic VXLAN Configuration Workflow
+
+This guide explains how to use the sample automation scripts that accompany this
+repository to deploy a baseline Cisco NX-OS VXLAN EVPN fabric.  The scripts live
+under `examples/` and are intentionally designed to be easy to customize.
+
+## Overview of the scripts
+
+| Script | Purpose |
+| --- | --- |
+| `examples/basic_vxlan_conf.py` | Generates feature, underlay, and overlay configuration for spines, leaves, border leaves, and border gateways.  Prompts for credentials and applies the configuration sequentially, asking for confirmation per device. |
+| `examples/vxlan_fabric_manager.py` | Builds on the basic script with optional YAML/JSON inventory parsing, service bundles (VRFs/VLANs/VNIs), and concurrent configuration pushes. |
+
+Both scripts share the same data models so you can evolve from the basic sample
+to the manager as your fabric grows.
+
+## Prerequisites
+
+1. Python 3.9+
+2. Install dependencies:
+   ```bash
+   pip install netmiko pyyaml
+   ```
+3. Ensure SSH reachability to each NX-OS switch from the automation host.
+4. Create a `logs/` directory or allow the scripts to do so automatically.
+
+## Running `basic_vxlan_conf.py`
+
+1. Inspect the sample inventory in the `build_sample_inventory` function to see
+   how roles, vPC pairs, and loopback subnet automation are defined.
+2. Execute the script:
+   ```bash
+   python examples/basic_vxlan_conf.py
+   ```
+3. When prompted, provide:
+   - Fabric name (used for logging/context only)
+   - Loopback supernet (e.g. `10.255.0.0/24`)
+   - NX-OS username and password
+4. The script previews the configuration for each device and requests
+   confirmation before applying it via SSH.
+
+### Loopback allocation logic
+
+* Leaves use the numerical suffix from their hostname (e.g. `leaf01` → host id 1).
+* Border leaves add an offset of 100 (e.g. `border_leaf01` → host id 101).
+* Border gateways add an offset of 200.
+* Spines add an offset of 50 to keep their addresses in a distinct range.
+
+Adjust the offsets inside `Device.loopback_ip` if you need different spacing.
+
+### vPC domain protection
+
+The configurator automatically assigns unique vPC domain IDs per pair starting
+at 10 and incrementing by 10.  If the automation encounters a collision it
+raises a descriptive exception so that you can adjust the policy.
+
+## Running `vxlan_fabric_manager.py`
+
+This script extends the baseline workflow with inventory/service files and
+parallel pushes.
+
+1. Optionally create an inventory file (`fabric.yml`):
+   ```yaml
+   loopback_base: 10.255.0.0/24
+   devices:
+     - name: leaf01
+       role: leaf
+       host: 192.0.2.101
+       vpc_pair: leaf_pair_1
+       metadata:
+         keepalive_dest: 192.0.2.102
+       tags: [primary]
+     - name: leaf02
+       role: leaf
+       host: 192.0.2.102
+       vpc_pair: leaf_pair_1
+       metadata:
+         keepalive_dest: 192.0.2.101
+   ```
+2. Optionally define overlay services (`services.yml`):
+   ```yaml
+   target_roles: [leaf, border_leaf]
+   vrfs:
+     - name: Tenant-A
+       vni: 10010
+       rd: 65000:10
+       export_rt: 65000:10
+       import_rt: 65000:10
+   vlans:
+     - vlan_id: 10
+       vni: 10100
+       description: Tenant-A-Web
+       vrf: Tenant-A
+   ```
+3. Run the manager:
+   ```bash
+   python examples/vxlan_fabric_manager.py --inventory fabric.yml --services services.yml
+   ```
+4. Supply credentials when prompted.  The script pushes configuration in
+   parallel while streaming success/failure per node.
+
+## Extending the automation
+
+* Add new roles or device types by extending the `DeviceRole` enum and
+  updating the configuration builder methods.
+* Modify `build_feature_config`, `build_underlay_config`, and
+  `build_overlay_config` to suit your standards.
+* Add new service types by expanding `ServiceBundle` with additional data
+  models and overriding the helper methods in `ServiceAwareConfigurator`.
+* Use the YAML inventory file to separate environment data from code, making it
+  easier to version-control your fabric topology.
+
+Feel free to fork these scripts into your own automation framework or integrate
+with task orchestrators such as Nornir, Salt, or Ansible.

--- a/Day2_Operations_Guide.md
+++ b/Day2_Operations_Guide.md
@@ -1,0 +1,119 @@
+# Day-2 Operations Playbook for NX-OS VXLAN Fabrics
+
+This playbook accompanies `examples/day2_fabric_operations.py` and shows how to
+extend a production VXLAN EVPN fabric safely.  The intent is to teach a repeat-
+able process that combines automated validation, staged configuration merges,
+and version-controlled backups so you can scale tenant onboarding without
+surprises.
+
+## When to Use This Workflow
+
+* **Onboard a new tenant VLAN/VNI** across the entire fabric or a subset of
+  leaf/border-leaf switches.
+* **Extend an existing VLAN** to additional access ports while reusing the same
+  Anycast Gateway and VNI mapping.
+* **Audit the current state** to confirm that VXLAN components (VLAN database,
+  VLAN-to-VNI mappings, and NVE peers) are aligned before you touch the config.
+
+## Inventory and Data Model
+
+The script expects a JSON inventory that lists every leaf/border device you may
+touch.  Each entry provides the management IP (used for SSH/NAPALM access), the
+fabric role, and optionally the loopback/VTEP address so that NVE peering can be
+validated.
+
+```json
+[
+  {
+    "hostname": "leaf01",
+    "mgmt_ip": "10.0.0.11",
+    "vtep_ip": "192.0.2.11",
+    "role": "leaf"
+  },
+  {
+    "hostname": "leaf02",
+    "mgmt_ip": "10.0.0.12",
+    "vtep_ip": "192.0.2.12",
+    "role": "leaf"
+  }
+]
+```
+
+You can maintain this inventory in Git alongside the script so every change is
+reviewed and documented.
+
+## VNI Allocation Strategy
+
+*The script defaults to `VNI = 100000 + VLAN_ID`*, matching the user's request
+for values such as `VLAN 200 → VNI 100200`.  The helper is easy to customise if
+your environment prefers a different formula (for example, `500000 + VLAN`).
+
+Best practices:
+
+1. **Keep VLAN/VNI IDs globally unique** to simplify operations and EVPN
+   troubleshooting.
+2. **Document the scheme** in your engineering standards so other engineers know
+   how to pre-allocate ranges for tenants.
+
+## Fabric Scope Decisions
+
+Many operations engineers debate whether to create VLANs everywhere or only on
+switches that host endpoints.  With EVPN, the control plane handles advertising
+MAC/IP reachability, so either model works:
+
+* **Fabric-wide VLANs** simplify automation and guarantee consistency but can
+  clutter the VLAN database when you have thousands of services.
+* **Scoped VLANs** (the default in the script) reduce the blast radius.  The
+  tool prompts you for a comma-separated list of switches so you can target only
+  the leafs that host the workload.
+
+You can change the default to "all" if you prefer ubiquitous VLAN creation.
+
+## Pre-Change Validation
+
+Before staging configuration, the script checks:
+
+* **`show vlan id <ID>`** — warns you if the VLAN already exists so you can
+  confirm that the change is an extension rather than a duplicate.
+* **`show nve vn-segment-vlan`** — verifies that the VLAN-to-VNI mapping matches
+  the expected value or is free.
+* **`show nve peers`** — ensures each target device reports its fellow VTEPs.
+
+If any validation fails, the device is skipped and clearly logged so you can fix
+the issue manually before re-running the automation.
+
+## Configuration Generation and Diff Review
+
+The configuration renderer builds the minimum viable snippet:
+
+* `vlan <ID>` with name and `vn-segment <VNI>`
+* `evpn` section with `vni <VNI> l2`
+* Optional Anycast Gateway configuration on the SVI when the tenant is L3-aware
+
+NAPALM stages the snippet as a merge candidate so you can run `compare_config()`
+and see the delta before committing.  Nothing is pushed without an explicit
+"yes" from the operator unless you intentionally run in `--dry-run` mode.
+
+## Backups and Rollback
+
+Every execution saves the running configuration to `backups/<hostname>`.  Track
+that directory in Git and commit snapshots after successful changes.  Rollback
+is as simple as checking out the previous commit and using `configure replace`
+or `load replace` with the saved file.
+
+For emergency recovery, NAPALM also supports `discard_config()` (used when you
+cancel) and `rollback()` if you would rather rely on device-native checkpoints.
+
+## Extending the Script
+
+The module is heavily commented so you can add new day-2 tasks:
+
+* Extend the `TenantVlanRequest` dataclass with DHCP relay, multicast, or QoS
+  attributes.
+* Add new validation helpers (for example, checking interface descriptions or
+  verifying that access ports are in the correct mode).
+* Integrate with a source of truth such as NetBox or Nautobot by replacing the
+  JSON loader with their APIs.
+
+Always enhance the automated checks first—config pushes should be the last step
+once the fabric is confirmed healthy.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,198 @@
-# codex_ai
+# Python Automation Playbook for Data Center Network Engineers
+
+This guide is designed as a practical, opinionated reference for Cisco Nexus (NX-OS) automation with Python. It assumes a network engineer's perspective and focuses on building maintainable, testable, and scalable tooling. The accompanying `examples/` directory contains runnable snippets that reinforce concepts from each section.
+
+## 1. Python Fundamentals Refresher
+
+### 1.1 Setting Up Your Environment
+* Install Python 3.10+ and `pipx` for isolated CLIs.
+* Use virtual environments (`python -m venv venv && source venv/bin/activate`) per project.
+* Adopt a project layout like:
+  ```text
+  project/
+  ├── README.md
+  ├── pyproject.toml  # dependency management with Poetry/hatch/pip-tools
+  ├── src/            # your Python packages
+  ├── tests/          # pytest-based tests
+  └── scripts/        # task entry points
+  ```
+
+### 1.2 Language Building Blocks
+* **Primitive types:** `int`, `float`, `bool`, `str`, `None`.
+* **Collections:** `list`, `tuple`, `set`, `dict`, `dataclass` (structured records).
+* **Control flow:** `if/elif/else`, `for` loops (iterate over collections), `while` loops (repeat until condition changes), `match` (3.10+ pattern matching).
+* **Error handling:** `try/except/else/finally`. Handle expected errors near where they occur; avoid broad `except Exception` unless you log/re-raise.
+* **Modules & packages:** Organize reusable code into modules. Import only what you need to keep namespaces clear.
+
+### 1.3 Essential Patterns
+* Use **type hints** for all function arguments and return values to document intent and enable static analysis with `mypy`.
+* Prefer **f-strings** for readability when formatting strings.
+* **Context managers** (`with open(...)`) manage resources like files or network sessions cleanly.
+* Handle sensitive data (passwords, tokens) via environment variables or secrets managers—never hard-code credentials.
+
+See `examples/python_basics.py` for runnable demonstrations of data structures, loops, list/dict comprehensions, and context managers.
+
+## 2. Structuring Code: Functions, Classes, and Modules
+
+### 2.1 When to Write a Function
+Functions are ideal for performing a single, well-defined task with input parameters and a return value.
+
+* Use when logic can be described as "Given X, produce Y" (e.g., normalize interface names, parse API responses).
+* Keep them short (≤20 lines is a good heuristic). Extract helper functions when you notice duplicate code or complex logic.
+* Pure functions (no side effects) are easier to test. Prefer them for data transformations.
+
+### 2.2 When to Create a Class
+Classes encapsulate state and behavior that belong together.
+
+* Use when you have a concept with lifecycle and data (e.g., an `NxosSwitch` that caches credentials, device facts, and provides methods like `get_vlans`).
+* Classes help hide implementation details and expose a clean interface.
+* Favor `dataclasses` for value objects (e.g., representing an interface or VLAN) with minimal boilerplate.
+* Limit inheritance depth. Prefer **composition**—inject dependencies via the constructor rather than creating "God" classes.
+
+`examples/functions_vs_classes.py` illustrates when to graduate from a procedural helper function to a class-based abstraction.
+
+## 3. Looping Strategically
+
+### 3.1 Choosing the Right Loop
+* Use `for` loops to iterate over a known collection or generator.
+* Use `while` loops when you must wait on a condition (e.g., polling a task until it completes).
+* Prefer comprehensions (`[port.name for port in ports if port.is_up]`) for simple transformations; they are concise and expressive.
+* Avoid deeply nested loops: extract inner loops into dedicated functions or generators.
+
+### 3.2 Flattening Triple-Nested Loops
+Example: iterating over data centers ➝ switches ➝ interfaces. Instead of three nested loops inline, create generators that yield work units and call reusable helper functions.
+
+```python
+from collections.abc import Iterable
+
+def iter_work_items(datacenters: Iterable[dict]) -> Iterable[tuple[str, str, dict]]:
+    for dc in datacenters:
+        for switch in dc["switches"]:
+            for interface in switch["interfaces"]:
+                yield dc["name"], switch["hostname"], interface
+
+for dc_name, hostname, interface in iter_work_items(dc_inventory):
+    handle_interface(dc_name, hostname, interface)
+```
+
+By isolating the inner logic, you can test `iter_work_items` and `handle_interface` independently, and you can replace the generator with a version that fetches data asynchronously without modifying the calling loop.
+
+### 3.3 Loop Control Best Practices
+* Use `enumerate(sequence, start=1)` when you need index + value.
+* Use `zip()` to iterate over multiple iterables in parallel.
+* Break early with `break` or skip iterations with `continue` when it improves clarity.
+* Guard complex loops with functions: `for interface in iter_switch_interfaces(inventory): ...`
+
+See `examples/loop_strategies.py` for patterns that keep nested loops clean and testable.
+
+## 4. Writing Modular, Scalable Automation
+
+### 4.1 Project Layout
+* **Core library (`src/`):** business logic, models, utilities.
+* **Entry points (`scripts/`):** thin wrappers that parse CLI arguments and call core functions.
+* **Configuration (`inventory/`, `settings.yaml`):** device definitions, credentials (encrypted), global defaults.
+* **Tests (`tests/`):** unit tests (fast, isolated), integration tests (require lab or simulation).
+
+### 4.2 Dependency Management
+* Use `pyproject.toml` with Poetry or Hatch; lock dependencies for reproducible builds.
+* Pin major versions of libraries like Nornir, NAPALM, and pyATS that you have tested.
+* Use `.pre-commit-config.yaml` to run linters (e.g., `black`, `ruff`, `mypy`, `pytest`) before committing.
+
+### 4.3 Configuration & Secrets
+* Store inventory data in YAML/JSON, but keep secrets in encrypted vaults (Ansible Vault, SOPS, HashiCorp Vault).
+* Use `.env` files with `python-dotenv` for local development (never commit them).
+* Provide sane defaults and allow overrides via CLI flags or environment variables.
+
+## 5. Concurrency & Scaling Workloads
+
+### 5.1 Nornir Overview
+[Nornir](https://nornir.readthedocs.io/) is a Python framework tailored for network automation. Key concepts:
+* **Inventory:** hosts, groups, defaults.
+* **Tasks:** Python callables executed per host.
+* **Runner:** controls concurrency (threaded by default).
+
+Example (`examples/nornir_threads.py`):
+```python
+from nornir import InitNornir
+from nornir.core.task import Task, Result
+
+def collect_facts(task: Task) -> Result:
+    facts = task.run(task=napalm_get, getters=["facts"])
+    hostname = facts.result["facts"]["hostname"]
+    return Result(host=task.host, result=f"Got facts for {hostname}")
+
+if __name__ == "__main__":
+    nr = InitNornir(config_file="config.yaml")
+    result = nr.run(task=collect_facts)
+    result.print_results()
+```
+* Customize `nr = InitNornir(...)` with `num_workers` to control parallelism.
+* Use `nr.filter()` to target device subsets.
+* Combine Nornir with rich logging (structlog/loguru) to capture per-host activity.
+
+### 5.2 Handling Massive Device Lists
+* Partition devices by site or role and run tasks per batch.
+* Use `nornir-salt` or job queues (Celery, Arq, Dramatiq) when tasks take minutes per host.
+* Implement exponential backoff and retries for transient SSH/API failures.
+* Use asynchronous libraries (`asyncio`, `asyncssh`, `scrapli`) when the tool supports it; Nornir 3+ offers experimental async runners.
+
+### 5.3 Multitasking Without Nornir
+* Use `concurrent.futures.ThreadPoolExecutor` for simple threaded workloads.
+* For CPU-bound parsing (rare in network automation), use `ProcessPoolExecutor`.
+* Rate-limit outbound connections with semaphores or token buckets to avoid overwhelming devices.
+
+`examples/concurrency_threadpool.py` shows how to create a threaded worker pool with graceful shutdown.
+
+## 6. Device Abstraction with NAPALM
+
+[NAPALM](https://napalm.readthedocs.io/) provides a vendor-neutral API for reading and writing network state.
+
+* Support for `get_facts`, `get_interfaces`, `load_merge_candidate`, `compare_config`, `commit_config`, and more.
+* Works well inside Nornir via `nornir-napalm`. You can run compliance checks and configuration pushes while handling rollbacks automatically.
+* Use `napalm_validate` to compare device state against a desired state expressed in YAML.
+
+`examples/napalm_compliance.py` demonstrates loading a configuration candidate, diffing it, and committing or rolling back safely.
+
+## 7. Testing with pyATS
+
+[pyATS](https://developer.cisco.com/docs/pyats/) from Cisco is excellent for validation and CI pipelines.
+
+* Define test cases with `aetest` classes.
+* Use `Genie` parsers to normalize command outputs.
+* Integrate pyATS with pytest by exporting pyATS testbeds and running them in GitLab/GitHub CI.
+
+`examples/pyats_example.py` includes a small `aetest` suite that logs into NX-OS devices, gathers interface data via Genie, and validates policies.
+
+## 8. Putting It Together: Workflow Blueprint
+
+1. **Plan:** Define desired outcomes, success criteria, and rollback plans.
+2. **Model:** Represent devices, interfaces, and policies as Python data structures (`dataclass`, `pydantic` models).
+3. **Build:** Implement pure functions for parsing/transforming data and classes for device/session management.
+4. **Automate:** Use Nornir or a custom runner to fan out tasks. Keep tasks idempotent.
+5. **Observe:** Log every action, capture diffs, tag deployments with change IDs.
+6. **Test:** Run unit tests, lint, and pyATS/Genie validations before and after changes.
+7. **Release:** Use CI pipelines to package scripts, run tests, and deploy to automation servers.
+
+## 9. Best Practices Checklist
+
+* [ ] Every module has clear responsibilities and docstrings.
+* [ ] Functions are single-purpose and annotated with types.
+* [ ] Classes hide state transitions and expose intentional methods.
+* [ ] Loops are shallow; reusable generators/functions flatten nested logic.
+* [ ] Configuration and secrets are externalized and version-controlled securely.
+* [ ] Concurrency is handled through frameworks (Nornir) or executors with robust error handling.
+* [ ] Tests cover success, failure, and rollback paths; pyATS/Genie provides integration checks.
+* [ ] Logging and metrics provide visibility into automation runs.
+* [ ] CI enforces formatting (`black`), linting (`ruff`), typing (`mypy`), and testing (`pytest`, `pyats run job`).
+* [ ] Documentation (like this README) stays up-to-date with tooling.
+
+## 10. Further Learning
+
+* Books: *Network Programmability and Automation (2nd Edition)*, *Automating and Orchestrating Networks with Ansible*.
+* Cisco DevNet labs for pyATS/Genie and NX-OS automation.
+* Community projects: `networktocode/nornir`, `ktbyers/netmiko`, `scrapli`.
+* Practice in a sandbox (Cisco DevNet, EVE-NG, CML). Automate real workflows such as interface compliance, VLAN deployments, and configuration backups.
+
+---
+
+Explore the `examples/` directory to see how these principles translate into code. Clone this repository, create a virtual environment, install dependencies as needed, and adapt the snippets to your environment.

--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -1,0 +1,176 @@
+# Python & Network Automation Quick Reference
+
+This quick-reference is designed as your companion when learning Python with a focus on data-center network automation (NX-OS, Nornir, NAPALM, pyATS, etc.). It supplements the main `README.md` playbook by providing concise definitions, when-to-use guidance, and discovery tips.
+
+## Core Python Building Blocks
+
+### Numbers: `int` and `float`
+- **`int`** (integer) represents whole numbers, e.g., VLAN IDs or interface counts.
+  ```python
+  vlan_id = 200  # good for VLANs, ASN, counts
+  ```
+  *Use when exact whole numbers are needed.*
+- **`float`** represents decimal numbers, e.g., link utilization percentages.
+  ```python
+  cpu_utilization = 67.5  # percentage with decimals
+  ```
+  *Use when measurements can contain fractions.*
+
+### `bool`
+- Stores `True` or `False` (binary decisions, feature toggles).
+  ```python
+  is_nexus = True
+  maintenance_mode = False
+  ```
+  *Use for status flags or conditional checks.*
+
+### `str`
+- Text data: hostnames, IPs, CLI commands.
+  ```python
+  hostname = "leaf01"
+  interface = "Ethernet1/1"
+  ```
+  *Use when storing textual identifiers or command strings.*
+
+### Collections
+- **`list`**: ordered, mutable sequence. Great for queues of tasks or device lists.
+  ```python
+  devices = ["leaf01", "leaf02", "spine01"]
+  devices.append("spine02")
+  ```
+  *Use when order matters and items may change.*
+- **`tuple`**: ordered, immutable sequence. Useful for fixed groupings like (ip, port).
+  ```python
+  netconf_endpoint = ("10.10.10.5", 830)
+  ```
+  *Use for read-only pairs or coordinate-style data.*
+- **`dict`**: key-value mapping. Ideal for structured device facts.
+  ```python
+  device = {
+      "hostname": "leaf01",
+      "mgmt_ip": "10.1.1.10",
+      "role": "leaf",
+      "vlans": [10, 20, 30]
+  }
+  ```
+  *Use when you want fast lookups by a key.*
+- **`set`** (bonus): unordered unique items. Handy for deduplicating VLANs or IPs.
+  ```python
+  vlans_seen = {10, 20, 20, 30}  # becomes {10, 20, 30}
+  ```
+
+### Control Flow: `if`, `elif`, `else`
+- Choose actions based on conditions (device role, feature state).
+  ```python
+  if device["role"] == "spine":
+      template = "spine_template.j2"
+  elif device["role"] == "leaf":
+      template = "leaf_template.j2"
+  else:
+      template = "default_template.j2"
+  ```
+  *Use to branch logic depending on device attributes or test results.*
+
+### Looping Constructs
+- **`for` loops** iterate over known collections (devices, interfaces, VLAN IDs).
+  ```python
+  for device in devices:
+      deploy_vlan(device, vlan_id=200)
+  ```
+- **Nested `for` loops** are acceptable when the relationships are natural (device → interface → command).
+  ```python
+  for device in devices:
+      for iface in device_interfaces(device):
+          for command in interface_commands(iface):
+              push_command(device, command)
+  ```
+  *Keep each loop focused. Extract helper functions to avoid deeply indented code.*
+- **`while` loops** repeat until a condition changes (polling job progress, waiting for convergence).
+  ```python
+  while not change_request.done():
+      time.sleep(5)
+      change_request.refresh()
+  ```
+  *Use when you cannot precompute how many iterations are needed.*
+
+### Functions vs. Classes
+- **Functions**: encapsulate a single task or calculation.
+  ```python
+  def get_spine_devices(inventory):
+      return [d for d in inventory if d["role"] == "spine"]
+  ```
+  *Use for stateless utilities or one-off actions.*
+- **Classes**: bundle state + behavior (e.g., connection sessions, reusable clients).
+  ```python
+  class VlanDeployer:
+      def __init__(self, nornir):
+          self.nornir = nornir
+
+      def deploy(self, vlan_id):
+          self.nornir.run(task=configure_vlan, vlan_id=vlan_id)
+  ```
+  *Use when you need to maintain context across multiple operations.*
+
+## Discovering Python Features Quickly
+
+- **Built-in help**:
+  ```python
+  help(str)
+  dir(device)
+  ```
+- **Official docs**: https://docs.python.org/3/ (search bar + library reference).
+- **Search tips**: use `"python <feature> example"` or `<module> site:docs.python.org` in your browser.
+- **`pydoc` CLI**: `python -m pydoc json` opens module documentation.
+- **Interactive REPL**: try snippets in `python` shell or `ipython` for quick experiments.
+
+## Package & Plugin Discovery
+
+- **PyPI (https://pypi.org)**: central index for Python packages. Search for automation libraries (e.g., "napalm nxos").
+- **`pip search` alternative**: use `pip index versions <package>` or PyPI web UI; `pip search` is deprecated.
+- **Project documentation**: always read the README or docs site linked on PyPI for usage examples.
+- **Source code**: GitHub repositories often include sample playbooks and tests.
+
+## Network Automation Libraries Cheat Sheet
+
+| Library | Purpose | Key Commands | Learn More |
+| --- | --- | --- | --- |
+| **Nornir** | Inventory-driven, multi-threaded automation framework. | `pip install nornir`<br>`nornir.init_nornir()` | https://nornir.tech |
+| **NAPALM** | Unified API for network device configuration/state retrieval. | `pip install napalm`
+`from napalm import get_network_driver` | https://napalm.readthedocs.io |
+| **pyATS / Genie** | Cisco testing & validation framework (state comparison, testbeds). | `pip install pyats[full]`
+`from genie.testbed import load` | https://developer.cisco.com/pyats |
+| **Netmiko** | Simplifies SSH connections & command execution. | `pip install netmiko`
+`from netmiko import ConnectHandler` | https://github.com/ktbyers/netmiko |
+| **Scrapli** | Fast, async-friendly network device driver library. | `pip install scrapli`
+`from scrapli import Scrapli` | https://scrapli.github.io |
+| **TextFSM** | Template-based parsing for CLI output. | `pip install textfsm` | https://github.com/google/textfsm |
+| **Jinja2** | Templating engine for config generation. | `pip install jinja2` | https://jinja.palletsprojects.com |
+
+### When to Choose What
+- **Nornir**: coordinating many devices concurrently with a structured inventory.
+- **NAPALM**: retrieving facts or pushing configuration via an abstracted API (e.g., standard interface to multiple vendors).
+- **pyATS**: test automation, snapshots, and state diffing—perfect for pre/post-change validation.
+- **Netmiko/Scrapli**: direct CLI automation when APIs are unavailable or as building blocks for custom tasks.
+- **TextFSM**: parse CLI output into structured data for reporting or comparisons.
+- **Jinja2**: render configuration templates, often combined with Nornir.
+
+## Structuring Clean, Scalable Code
+
+1. **Modularize**: split logic into functions/modules. Keep each function focused on a single concern.
+2. **Abstract nested loops**: turn inner loops into helper functions so top-level workflows remain readable.
+3. **Use configuration files**: store inventory, credentials, and templates outside of code (`yaml`, `json`).
+4. **Tests**: start with unit tests for helpers and integration tests for workflows (`pytest`, pyATS jobs).
+5. **Logging**: use Python’s `logging` module to track actions across devices.
+6. **Concurrency**: prefer frameworks (Nornir, asyncio, concurrent.futures) instead of manual threading.
+7. **Documentation**: docstrings + README sections for new modules, keep this `TUTORIAL.md` updated with discoveries.
+
+## Continual Learning Workflow
+
+1. **Identify the task** (e.g., automate VLAN deployment).
+2. **Search** Python docs + relevant library docs for existing solutions.
+3. **Prototype** in a sandbox or lab with a small inventory.
+4. **Refine** by refactoring into functions/classes.
+5. **Add tests** to lock behavior.
+6. **Document** findings here to build your personalized reference.
+
+> 💡 **Tip**: Whenever you learn a new module or pattern, capture a one-sentence summary and a minimal code snippet in this file. Over time, it becomes your network automation cookbook.

--- a/examples/basic_vxlan_conf.py
+++ b/examples/basic_vxlan_conf.py
@@ -1,0 +1,344 @@
+"""Basic VXLAN EVPN configuration workflow for Cisco NX-OS fabrics.
+
+This script demonstrates a production-ready pattern for generating and pushing
+baseline VXLAN/EVPN configurations for fabrics composed of spines, leaves,
+border leaves, and border gateways.  The goals of the design are:
+
+* keep the workflow modular and easy to extend with new features
+* avoid accidental configuration drift such as duplicated vPC domain IDs
+* provide extensive commentary so new automation engineers can follow along
+* offer an opinionated starting point that you can adapt to your environment
+
+The script focuses on three major sections of a brownfield/greenfield bring-up:
+
+1. Feature enablement (``feature nv overlay`` and friends)
+2. Underlay configuration (loopback interfaces, PIM/ISIS/BGP underlay, etc.)
+3. Overlay configuration (NVE interface, VLAN-to-VNI mappings, EVPN services)
+
+The script expects ``netmiko`` to be installed so that it can open CLI sessions
+to Nexus platforms over SSH.  You can install it with ``pip install netmiko``.
+The configuration snippets are intentionally simplified yet production-ready and
+can easily be expanded by editing the helper methods in ``VXLANConfigurator``.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from getpass import getpass
+import ipaddress
+from pathlib import Path
+from typing import Dict, List, Optional, Sequence, Tuple
+
+from netmiko import ConnectHandler  # type: ignore
+from netmiko.ssh_exception import NetmikoTimeoutException, NetmikoAuthenticationException  # type: ignore
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+class DeviceRole(str, Enum):
+    """Roles that exist in a typical VXLAN EVPN fabric."""
+
+    SPINE = "spine"
+    LEAF = "leaf"
+    BORDER_LEAF = "border_leaf"
+    BORDER_GATEWAY = "border_gateway"
+
+
+@dataclass
+class Device:
+    """Represents a fabric node and its automation metadata."""
+
+    name: str
+    role: DeviceRole
+    host: str
+    loopback_base: str
+    vpc_pair: Optional[str] = None
+    asn: Optional[int] = None
+    tags: Tuple[str, ...] = ()
+    metadata: Dict[str, str] = field(default_factory=dict)
+
+    def loopback_ip(self) -> str:
+        """Return a deterministic loopback IP derived from the device name and role."""
+        base_network = ipaddress.ip_network(self.loopback_base)
+
+        # Extract numeric suffix from device name.  If no explicit digits are present,
+        # we fall back to the last octet in order of appearance to keep the logic safe.
+        suffix_digits = "".join(ch for ch in self.name if ch.isdigit())
+        suffix = int(suffix_digits) if suffix_digits else 1
+
+        role_offset = {
+            DeviceRole.LEAF: 0,
+            DeviceRole.SPINE: 50,
+            DeviceRole.BORDER_LEAF: 100,
+            DeviceRole.BORDER_GATEWAY: 200,
+        }[self.role]
+
+        host_id = suffix + role_offset
+        # Guard against generating an IP outside of the provided subnet.
+        if host_id >= base_network.num_addresses:
+            raise ValueError(
+                f"Loopback subnet {self.loopback_base} too small for host id {host_id}"
+            )
+
+        ip_address = base_network[host_id]
+        return str(ip_address)
+
+
+# ---------------------------------------------------------------------------
+# Configuration builder
+# ---------------------------------------------------------------------------
+
+
+class VXLANConfigurator:
+    """Generate and push VXLAN EVPN configurations for a fabric."""
+
+    def __init__(self, devices: Sequence[Device], fabric_name: str = "DC1") -> None:
+        self.devices = list(devices)
+        self.fabric_name = fabric_name
+        self.vpc_domain_registry: Dict[str, int] = {}
+
+    # ----------------------------
+    # Feature configuration
+    # ----------------------------
+    def build_feature_config(self, device: Device) -> List[str]:
+        """Return feature enablement commands specific to the device."""
+        commands = [
+            "terminal dont-ask",
+            "feature nv overlay",
+            "feature ospf",  # Replace with ISIS/BGP as required
+            "feature bgp",
+            "feature pim",
+            "feature lacp",
+        ]
+
+        # Enable NDFC compatibility or fabric automation tags if needed.
+        if "ndfc-managed" in device.tags:
+            commands.append("feature ndp")
+        return commands
+
+    # ----------------------------
+    # Underlay configuration
+    # ----------------------------
+    def build_underlay_config(self, device: Device) -> List[str]:
+        """Return underlay commands such as loopbacks, routing, and PIM."""
+        loopback_ip = device.loopback_ip()
+        commands = [
+            f"interface loopback0",
+            "  description Fabric-Loopback",
+            f"  ip address {loopback_ip}/32",
+            "  ip router ospf UNDERLAY area 0.0.0.0",
+            "exit",
+            "router ospf UNDERLAY",
+            f"  router-id {loopback_ip}",
+            "  passive-interface default",
+            "exit",
+        ]
+
+        if device.role in {DeviceRole.LEAF, DeviceRole.BORDER_LEAF, DeviceRole.BORDER_GATEWAY}:
+            commands.extend(self._build_vpc_commands(device))
+        return commands
+
+    def _build_vpc_commands(self, device: Device) -> List[str]:
+        """Construct vPC configuration for nodes that participate in pairs."""
+        if not device.vpc_pair:
+            # Leaves not running vPC (e.g., single-attached) skip this section.
+            return []
+
+        domain_id = self._allocate_vpc_domain(device.vpc_pair)
+        peer_link = device.metadata.get("peer_link", "port-channel10")
+        keepalive = device.metadata.get("keepalive_src", device.loopback_ip())
+        keepalive_dest = device.metadata.get("keepalive_dest")
+
+        if not keepalive_dest:
+            raise ValueError(
+                f"Missing keepalive destination for {device.name}. Add 'keepalive_dest' metadata."
+            )
+
+        commands = [
+            f"vpc domain {domain_id}",
+            f"  role priority {10 if 'primary' in device.tags else 20}",
+            f"  peer-keepalive destination {keepalive_dest} source {keepalive} vrf management",
+            "  peer-switch",
+            f"interface {peer_link}",
+            "  switchport",
+            "  switchport mode trunk",
+            "  spanning-tree port type network",
+            "  vpc peer-link",
+            "exit",
+        ]
+        return commands
+
+    def _allocate_vpc_domain(self, pair_name: str) -> int:
+        """Ensure a unique vPC domain for each pair and return it."""
+        if pair_name in self.vpc_domain_registry:
+            return self.vpc_domain_registry[pair_name]
+
+        base_id = 10 + len(self.vpc_domain_registry) * 10
+        if base_id in self.vpc_domain_registry.values():
+            raise RuntimeError("vPC domain collision detected; adjust base allocation policy")
+        self.vpc_domain_registry[pair_name] = base_id
+        return base_id
+
+    # ----------------------------
+    # Overlay configuration
+    # ----------------------------
+    def build_overlay_config(self, device: Device) -> List[str]:
+        """Construct overlay/NVE commands."""
+        loopback_ip = device.loopback_ip()
+        commands = [
+            "interface nve1",
+            "  no shutdown",
+            f"  source-interface loopback0",
+            "  host-reachability protocol bgp",
+            "exit",
+            "router bgp 65000",
+            f"  router-id {loopback_ip}",
+            "  address-family l2vpn evpn",
+            "    retain route-target all",
+            "  exit",
+            "exit",
+        ]
+
+        if device.role in {DeviceRole.BORDER_LEAF, DeviceRole.BORDER_GATEWAY}:
+            commands.extend(
+                [
+                    "  address-family ipv4 unicast",
+                    "    redistribute connected",
+                    "  exit",
+                ]
+            )
+        return commands
+
+    # ----------------------------
+    # Orchestration helpers
+    # ----------------------------
+    def device_config(self, device: Device) -> List[str]:
+        """Return the full ordered configuration for a device."""
+        config: List[str] = []
+        config.extend(self.build_feature_config(device))
+        config.extend(self.build_underlay_config(device))
+        config.extend(self.build_overlay_config(device))
+        return config
+
+    def push_config(self, device: Device, username: str, password: str) -> None:
+        """Connect to the device and push the generated configuration."""
+        connection_params = {
+            "device_type": "cisco_nxos",
+            "host": device.host,
+            "username": username,
+            "password": password,
+            "session_log": f"logs/{device.name}.log",
+        }
+
+        Path("logs").mkdir(exist_ok=True)
+
+        commands = self.device_config(device)
+        try:
+            with ConnectHandler(**connection_params) as conn:
+                conn.send_config_set(commands)
+                conn.save_config()
+        except NetmikoAuthenticationException as exc:
+            raise RuntimeError(f"Authentication failed for {device.name}: {exc}") from exc
+        except NetmikoTimeoutException as exc:
+            raise RuntimeError(f"Timed out connecting to {device.name}: {exc}") from exc
+
+    def deploy(self, username: str, password: str) -> None:
+        """Push configuration to all devices sequentially."""
+        for device in self.devices:
+            print(f"\n--- Deploying to {device.name} ({device.role}) ---")
+            commands = self.device_config(device)
+            print("Preview configuration:")
+            for line in commands:
+                print(f"  {line}")
+
+            confirmation = input("Apply this configuration? [y/N]: ").strip().lower()
+            if confirmation != "y":
+                print(f"Skipping {device.name} at user request.")
+                continue
+
+            self.push_config(device, username, password)
+            print(f"Configuration pushed successfully to {device.name}.")
+
+
+# ---------------------------------------------------------------------------
+# Example usage
+# ---------------------------------------------------------------------------
+
+def build_sample_inventory(loopback_subnet: str) -> List[Device]:
+    """Return an inventory tailored to a dual-spine/leaf fabric."""
+    return [
+        Device(
+            name="spine01",
+            role=DeviceRole.SPINE,
+            host="198.18.1.11",
+            loopback_base=loopback_subnet,
+            asn=65010,
+        ),
+        Device(
+            name="spine02",
+            role=DeviceRole.SPINE,
+            host="198.18.1.12",
+            loopback_base=loopback_subnet,
+            asn=65010,
+        ),
+        Device(
+            name="leaf01",
+            role=DeviceRole.LEAF,
+            host="198.18.2.21",
+            loopback_base=loopback_subnet,
+            vpc_pair="leaf_pair_1",
+            tags=("primary",),
+            metadata={"keepalive_dest": "198.18.2.22"},
+        ),
+        Device(
+            name="leaf02",
+            role=DeviceRole.LEAF,
+            host="198.18.2.22",
+            loopback_base=loopback_subnet,
+            vpc_pair="leaf_pair_1",
+            metadata={"keepalive_dest": "198.18.2.21"},
+        ),
+        Device(
+            name="border_leaf01",
+            role=DeviceRole.BORDER_LEAF,
+            host="198.18.3.31",
+            loopback_base=loopback_subnet,
+            vpc_pair="border_leaf_pair",
+            tags=("primary",),
+            metadata={"keepalive_dest": "198.18.3.32"},
+        ),
+        Device(
+            name="border_leaf02",
+            role=DeviceRole.BORDER_LEAF,
+            host="198.18.3.32",
+            loopback_base=loopback_subnet,
+            vpc_pair="border_leaf_pair",
+            metadata={"keepalive_dest": "198.18.3.31"},
+        ),
+        Device(
+            name="border_gateway01",
+            role=DeviceRole.BORDER_GATEWAY,
+            host="198.18.3.41",
+            loopback_base=loopback_subnet,
+        ),
+    ]
+
+
+def main() -> None:
+    """Entry point when executing the script directly."""
+    fabric_name = input("Fabric name [DC1]: ").strip() or "DC1"
+    loopback_subnet = input("Loopback supernet for automation [10.255.0.0/24]: ").strip() or "10.255.0.0/24"
+
+    inventory = build_sample_inventory(loopback_subnet)
+    configurator = VXLANConfigurator(inventory, fabric_name=fabric_name)
+
+    username = input("Username: ")
+    password = getpass("Password: ")
+
+    configurator.deploy(username, password)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/concurrency_threadpool.py
+++ b/examples/concurrency_threadpool.py
@@ -1,0 +1,39 @@
+"""ThreadPoolExecutor pattern for running tasks across many switches."""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Iterable
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+LOGGER = logging.getLogger(__name__)
+
+
+def collect_facts(hostname: str) -> str:
+    """Placeholder for a function that connects to a device and gathers data."""
+
+    # Replace this with real logic (e.g., NAPALM, Scrapli, custom API calls).
+    LOGGER.info("Collecting facts for %s", hostname)
+    return f"Facts for {hostname}"
+
+
+def run_in_threads(hosts: Iterable[str], max_workers: int = 20) -> dict[str, str]:
+    """Execute `collect_facts` concurrently while handling failures gracefully."""
+
+    results: dict[str, str] = {}
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        future_map = {executor.submit(collect_facts, host): host for host in hosts}
+        for future in as_completed(future_map):
+            host = future_map[future]
+            try:
+                results[host] = future.result()
+            except Exception as exc:  # noqa: BLE001 - log and continue
+                LOGGER.exception("%s failed: %s", host, exc)
+    return results
+
+
+if __name__ == "__main__":
+    device_list = [f"leaf-{index}" for index in range(1, 11)]
+    aggregated = run_in_threads(device_list, max_workers=4)
+    print(aggregated)

--- a/examples/day2_fabric_operations.py
+++ b/examples/day2_fabric_operations.py
@@ -1,0 +1,481 @@
+"""Day-2 fabric operations helper for Cisco NX-OS VXLAN/EVPN fabrics.
+
+This script focuses on the tasks you repeatedly perform after the fabric is
+built: onboarding a new tenant, extending VLANs/VXLANs, and validating that the
+state of the fabric remains healthy.  The script intentionally contains a large
+amount of commentary so that newcomers can learn both the *why* and *how* of
+automation while staying production-ready.
+
+Key goals of the design:
+
+* keep workflows modular so you can extend them with new checks later
+* double-check the fabric before touching the configuration ("trust but verify")
+* always show an actionable diff before committing changes
+* integrate with Git so you can roll back quickly if something goes wrong
+
+The implementation leans on NAPALM because it provides a driver that can push
+merge configurations to NX-OS while also exposing `compare_config()` and
+`rollback()` helpers.  If you prefer Netmiko or the NX-API, you can swap the
+transport within the `DeviceSession` class without changing the higher-level
+workflow.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from getpass import getpass
+import ipaddress
+import json
+from pathlib import Path
+from textwrap import dedent
+from typing import Dict, Iterable, List, Optional
+
+from napalm import get_network_driver  # type: ignore
+from napalm.base.base import NetworkDriver  # type: ignore
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TenantVlanRequest:
+    """Describe the VLAN/VXLAN service that we want to roll out.
+
+    Attributes:
+        tenant: Logical tenant name (used for VRF, route-targets, etc.).
+        vlan_id: Numeric VLAN identifier.  We assume classic 1-4094 VLAN IDs.
+        l2_only: Whether the tenant is L2-only (False = needs an Anycast GW).
+        svi_gateway: Optional IPv4 gateway address (e.g. "10.10.200.1/24").
+        vrf: Optional VRF name; default is derived from the tenant.
+        fabric_scope: Either "all" for a fabric-wide VLAN, or an iterable of
+            device hostnames where the VLAN should exist.
+    """
+
+    tenant: str
+    vlan_id: int
+    l2_only: bool
+    svi_gateway: Optional[str] = None
+    vrf: Optional[str] = None
+    fabric_scope: Optional[Iterable[str]] = None
+
+    def computed_vrf(self) -> str:
+        """Return the VRF name to use for this tenant.
+
+        The default VRF naming convention is ``VRF_<TENANT>``.  You can adjust
+        this function to match your local standard.
+        """
+
+        if self.vrf:
+            return self.vrf
+        return f"VRF_{self.tenant.upper()}"
+
+    def computed_vni(self) -> int:
+        """Derive the VNI using the "100 + VLAN" pattern recommended by the user.
+
+        You can replace this with another function (for example 10000 + VLAN)
+        without modifying any other part of the script.
+        """
+
+        return 100_000 + self.vlan_id
+
+
+@dataclass
+class DeviceInventoryItem:
+    """Simple representation of a fabric node in our inventory."""
+
+    hostname: str
+    mgmt_ip: str
+    role: str  # e.g. "leaf", "border_leaf", "spine"
+    vtep_ip: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Device session helpers
+# ---------------------------------------------------------------------------
+
+
+class DeviceSession:
+    """Thin wrapper around a NAPALM session.
+
+    The wrapper lets us centralise credential handling, optional arguments, and
+    add strongly-typed helper methods for the commands we run frequently.
+    """
+
+    def __init__(self, host: str, username: str, password: str) -> None:
+        driver = get_network_driver("nxos_ssh")
+        optional_args = {"port": 22}
+        self.connection: NetworkDriver = driver(
+            hostname=host,
+            username=username,
+            password=password,
+            optional_args=optional_args,
+        )
+
+    def __enter__(self) -> "DeviceSession":
+        self.connection.open()
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.connection.close()
+
+    # -- Show commands -----------------------------------------------------
+
+    def cli(self, commands: Dict[str, str]) -> Dict[str, str]:
+        """Run multiple CLI commands and return their raw output."""
+
+        return self.connection.cli(commands)
+
+    def checkpoint(self, filename: Path) -> None:
+        """Save the current running configuration to disk.
+
+        NX-OS supports `checkpoint` to create a rollback file on the device.
+        The `save_config` call downloads the running config locally so that we
+        can commit it to Git and roll back quickly by restoring the previous
+        version.  This design keeps the workflow vendor-neutral: you can push
+        the snapshot into Git, or into your preferred CMDB.
+        """
+
+        filename.write_text(self.connection.get_config()["running"])
+
+    # -- Config management -------------------------------------------------
+
+    def load_merge(self, config_snippet: str) -> None:
+        """Stage a merge configuration on the device."""
+
+        self.connection.load_merge_candidate(config=config_snippet)
+
+    def compare(self) -> str:
+        """Return the diff between the candidate configuration and running."""
+
+        return self.connection.compare_config()
+
+    def commit(self, message: str = "") -> None:
+        """Commit the candidate configuration."""
+
+        self.connection.commit_config(message)
+
+    def discard(self) -> None:
+        """Discard the candidate configuration."""
+
+        self.connection.discard_config()
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_vlan(session: DeviceSession, vlan_id: int) -> bool:
+    """Return True when the VLAN either does not exist or matches expectations.
+
+    The goal is to warn operators when the VLAN already exists so they can
+    decide whether this run represents an expansion (for example, extending the
+    VLAN to additional leafs) or an accidental duplicate request.  Returning
+    ``True`` keeps the workflow moving while still highlighting the situation.
+    """
+
+    try:
+        output = session.cli({"vlan": f"show vlan id {vlan_id}"})["vlan"]
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        print(f"[WARN] Unable to validate VLAN {vlan_id}: {exc}")
+        return False
+
+    if f"VLAN {vlan_id}" in output:
+        print(f"[INFO] VLAN {vlan_id} already exists; validating attributes before merge.")
+    else:
+        print(f"[INFO] VLAN {vlan_id} not found; will create it as part of this run.")
+    return True
+
+
+def validate_vni_mapping(session: DeviceSession, vlan_id: int, vni: int) -> bool:
+    """Ensure the VLAN-to-VNI mapping is not already in use with a different VNI."""
+
+    command = {"vn-seg": "show nve vn-segment-vlan"}
+    try:
+        output = session.cli(command)["vn-seg"]
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        print(f"[WARN] Unable to validate VNI mapping: {exc}")
+        return False
+
+    for line in output.splitlines():
+        if f"{vlan_id}" in line and "".join(line.split()) != "":
+            if str(vni) not in line:
+                print(
+                    f"[ERROR] VLAN {vlan_id} already mapped to a different VNI."
+                )
+                return False
+            print(f"[INFO] VLAN {vlan_id} already mapped to VNI {vni}; will reuse it.")
+            return True
+
+    print(f"[INFO] VLAN {vlan_id} not yet mapped to VNI {vni}; ready to configure.")
+    return True
+
+
+def validate_nve_peering(session: DeviceSession, peer_vtep: str) -> bool:
+    """Verify that the NVE interface sees the remote VTEP.
+
+    We assume Loopback0 is the VTEP source address.  The command checks the NVE
+    peer list so we can highlight missing connectivity before pushing configs.
+    """
+
+    try:
+        output = session.cli({"peers": "show nve peers"})["peers"]
+    except Exception as exc:  # pragma: no cover - defensive fallback
+        print(f"[WARN] Unable to validate NVE peers: {exc}")
+        return False
+
+    return peer_vtep in output
+
+
+# ---------------------------------------------------------------------------
+# Configuration rendering helpers
+# ---------------------------------------------------------------------------
+
+
+def render_vlan_config(request: TenantVlanRequest) -> str:
+    """Render the VLAN/NVE configuration snippet for NX-OS."""
+
+    vlan_id = request.vlan_id
+    vni = request.computed_vni()
+    svi_lines: List[str] = []
+
+    if not request.l2_only and request.svi_gateway:
+        gateway_ip = ipaddress.ip_interface(request.svi_gateway)
+        svi_lines = [
+            f"interface Vlan{vlan_id}",
+            "  no shutdown",
+            f"  description Tenant {request.tenant} Anycast Gateway",
+            f"  vrf member {request.computed_vrf()}",
+            f"  ip address {gateway_ip.ip} {gateway_ip.network.netmask}",
+            "  fabric forwarding mode anycast-gateway",
+        ]
+
+    template = [
+        f"vlan {vlan_id}",
+        f"  name {request.tenant}_VLAN_{vlan_id}",
+        "  vn-segment {vni}",
+        "",
+        f"evpn",
+        f"  vni {vni} l2",
+        f"    rd auto",
+        f"    route-target import auto",
+        f"    route-target export auto",
+    ]
+
+    config_lines = template
+    if svi_lines:
+        config_lines.append("")
+        config_lines.extend(svi_lines)
+
+    return "\n".join(config_lines) + "\n"
+
+
+# ---------------------------------------------------------------------------
+# Workflow orchestration
+# ---------------------------------------------------------------------------
+
+
+def load_inventory(path: Path) -> List[DeviceInventoryItem]:
+    """Load a JSON inventory file from disk.
+
+    The inventory should look like::
+
+        [
+          {
+            "hostname": "leaf01",
+            "mgmt_ip": "10.0.0.11",
+            "vtep_ip": "192.0.2.11",
+            "role": "leaf"
+          }
+        ]
+    """
+
+    raw = json.loads(path.read_text())
+    return [
+        DeviceInventoryItem(**item)
+        for item in raw
+        if item.get("role") in {"leaf", "border_leaf", "border_gateway"}
+    ]
+
+
+def filter_scope(
+    inventory: List[DeviceInventoryItem], request: TenantVlanRequest
+) -> List[DeviceInventoryItem]:
+    """Return the devices that should receive the configuration."""
+
+    if request.fabric_scope is None or request.fabric_scope == "all":
+        return inventory
+
+    scope = set(host for host in request.fabric_scope)
+    return [item for item in inventory if item.hostname in scope]
+
+
+def day2_workflow(
+    request: TenantVlanRequest,
+    inventory: List[DeviceInventoryItem],
+    username: str,
+    password: str,
+    dry_run: bool = False,
+) -> None:
+    """Execute the day-2 VLAN onboarding workflow across the selected devices."""
+
+    target_devices = filter_scope(inventory, request)
+    vni = request.computed_vni()
+    config_snippet = render_vlan_config(request)
+
+    for device in target_devices:
+        print("-" * 79)
+        print(f"[INFO] Processing {device.hostname} ({device.mgmt_ip})")
+
+        with DeviceSession(device.mgmt_ip, username, password) as session:
+            # --- 1) Take a snapshot before touching anything -----------------
+            snapshot_path = Path(f"backups/{device.hostname}_running.cfg")
+            snapshot_path.parent.mkdir(exist_ok=True)
+            session.checkpoint(snapshot_path)
+            print(f"[INFO] Saved running config snapshot to {snapshot_path}")
+
+            # --- 2) Validate the current state --------------------------------
+            vlan_ok = validate_vlan(session, request.vlan_id)
+            vni_ok = validate_vni_mapping(session, request.vlan_id, vni)
+
+            if not (vlan_ok and vni_ok):
+                print(
+                    f"[ERROR] Skipping {device.hostname} due to validation failure."
+                )
+                continue
+
+            # Optional: verify NVE peer reachability by checking loopback IPs of
+            # other target devices.  We only warn if we cannot find all peers.
+            for peer in target_devices:
+                if peer.hostname == device.hostname:
+                    continue
+                peer_vtep = peer.vtep_ip or peer.mgmt_ip
+                if not peer_vtep:
+                    continue
+                peer_reachable = validate_nve_peering(session, peer_vtep)
+                if not peer_reachable:
+                    print(
+                        f"[WARN] {device.hostname} does not report NVE peer {peer_vtep}"
+                    )
+
+            # --- 3) Stage the merge configuration ----------------------------
+            session.load_merge(config_snippet)
+            diff = session.compare()
+            if not diff.strip():
+                print(f"[INFO] No changes required on {device.hostname}.")
+                session.discard()
+                continue
+
+            print("[INFO] Proposed diff:")
+            print(diff)
+
+            if dry_run:
+                print(
+                    "[DRY-RUN] Skipping commit because dry_run=True."
+                )
+                session.discard()
+                continue
+
+            choice = input(
+                f"Apply the changes to {device.hostname}? Type 'yes' to commit, anything else to abort: "
+            )
+            if choice.strip().lower() != "yes":
+                print("[INFO] Discarding staged config.")
+                session.discard()
+                continue
+
+            session.commit(message=f"Automated VLAN {request.vlan_id} deployment")
+            print(f"[INFO] Committed changes on {device.hostname}.")
+
+
+# ---------------------------------------------------------------------------
+# User interaction helpers
+# ---------------------------------------------------------------------------
+
+
+def prompt_for_request() -> TenantVlanRequest:
+    """Collect the tenant/VLAN parameters interactively from the operator."""
+
+    tenant = input("Tenant name (e.g. ACME): ").strip()
+    vlan_id = int(input("VLAN ID (e.g. 200): ").strip())
+    scope_raw = input(
+        "Fabric scope (comma separated hostnames or 'all' for every leaf): "
+    ).strip()
+
+    l2_only = input("Is this L2-only? (yes/no): ").strip().lower().startswith("y")
+
+    svi_gateway: Optional[str] = None
+    if not l2_only:
+        svi_gateway = input(
+            "Anycast gateway IPv4 address (CIDR, e.g. 10.10.200.1/24): "
+        ).strip()
+
+    scope: Optional[Iterable[str]]
+    if scope_raw.lower() == "all" or not scope_raw:
+        scope = "all"
+    else:
+        scope = [item.strip() for item in scope_raw.split(",") if item.strip()]
+
+    return TenantVlanRequest(
+        tenant=tenant,
+        vlan_id=vlan_id,
+        l2_only=l2_only,
+        svi_gateway=svi_gateway,
+        fabric_scope=scope,
+    )
+
+
+def main() -> None:
+    """Entry point for the command-line workflow."""
+
+    print(
+        dedent(
+            """
+            Day-2 Fabric Operations
+            ======================
+
+            This helper guides you through adding a VLAN/VNI to a VXLAN EVPN fabric.
+            You will need:
+              * a JSON inventory file describing the leaf/border leaf nodes
+              * reachability to the management interface of those switches
+              * network credentials with permission to configure the fabric
+
+            Tip: keep the `backups/` directory under Git.  Each time you run the
+            script, you will collect a fresh snapshot that you can version and
+            roll back easily by checking out the previous commit and copying the
+            configuration back to the device (`configure replace` on NX-OS).
+            """
+        )
+    )
+
+    inventory_path = Path(
+        input("Path to inventory JSON (default: inventory.json): ").strip() or "inventory.json"
+    )
+    if not inventory_path.exists():
+        raise FileNotFoundError(
+            f"Inventory file {inventory_path} not found. Create it before running the script."
+        )
+
+    inventory = load_inventory(inventory_path)
+    if not inventory:
+        raise RuntimeError("Inventory does not contain any leaf/border devices.")
+
+    username = input("Username: ").strip()
+    password = getpass("Password: ")
+
+    request = prompt_for_request()
+
+    dry_run = input("Run in dry-run mode? (yes/no): ").strip().lower().startswith("y")
+
+    day2_workflow(
+        request=request,
+        inventory=inventory,
+        username=username,
+        password=password,
+        dry_run=dry_run,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/functions_vs_classes.py
+++ b/examples/functions_vs_classes.py
@@ -1,0 +1,61 @@
+"""Deciding between functions and classes.
+
+This file demonstrates when simple helper functions are enough and when a
+class provides a cleaner abstraction with lifecycle management.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Iterable
+
+from python_basics import Interface
+
+
+def build_interface_map(interfaces: Iterable[Interface]) -> dict[str, Interface]:
+    """Return a name ➝ Interface mapping using a pure function."""
+
+    return {interface.name: interface for interface in interfaces}
+
+
+@dataclass(slots=True)
+class ChangeTicket:
+    """Encapsulate the state and workflow for an automation change ticket."""
+
+    change_id: str
+    created_at: datetime = field(default_factory=datetime.utcnow)
+    devices: list[str] = field(default_factory=list)
+    completed: bool = False
+
+    def add_device(self, hostname: str) -> None:
+        if hostname not in self.devices:
+            self.devices.append(hostname)
+
+    def mark_complete(self) -> None:
+        self.completed = True
+
+    def to_payload(self) -> dict[str, str | bool | list[str]]:
+        """Return a serializable representation for APIs or logs."""
+
+        return {
+            "change_id": self.change_id,
+            "created_at": self.created_at.isoformat(),
+            "devices": self.devices,
+            "completed": self.completed,
+        }
+
+
+if __name__ == "__main__":
+    demo_interfaces = [
+        Interface(name="Eth1/1", enabled=True),
+        Interface(name="Eth1/48", enabled=False),
+    ]
+    interface_map = build_interface_map(demo_interfaces)
+    print("Interface map:", interface_map)
+
+    ticket = ChangeTicket(change_id="CHG12345")
+    for hostname in ["leaf-1", "leaf-2"]:
+        ticket.add_device(hostname)
+    ticket.mark_complete()
+    print("Ticket payload:", ticket.to_payload())

--- a/examples/loop_strategies.py
+++ b/examples/loop_strategies.py
@@ -1,0 +1,66 @@
+"""Loop patterns for scalable automation."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class Switch:
+    name: str
+    location: str
+    interfaces: list[str]
+
+
+@dataclass(slots=True)
+class WorkItem:
+    datacenter: str
+    switch: str
+    interface: str
+
+
+def iter_interfaces(datacenters: Iterable[dict]) -> Iterator[WorkItem]:
+    """Yield work items while flattening nested structures."""
+
+    for datacenter in datacenters:
+        for switch_data in datacenter["switches"]:
+            switch = Switch(**switch_data)
+            for interface in switch.interfaces:
+                yield WorkItem(datacenter=datacenter["name"], switch=switch.name, interface=interface)
+
+
+def batched(iterable: Iterable[WorkItem], batch_size: int) -> Iterator[list[WorkItem]]:
+    """Group work items into batches to limit concurrent sessions."""
+
+    batch: list[WorkItem] = []
+    for item in iterable:
+        batch.append(item)
+        if len(batch) == batch_size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+if __name__ == "__main__":
+    fabric_inventory = [
+        {
+            "name": "DC1",
+            "switches": [
+                {"name": "leaf-1", "location": "row-1", "interfaces": ["Eth1/1", "Eth1/2"]},
+                {"name": "leaf-2", "location": "row-1", "interfaces": ["Eth1/1", "Eth1/48"]},
+            ],
+        },
+        {
+            "name": "DC2",
+            "switches": [
+                {"name": "leaf-5", "location": "row-3", "interfaces": ["Eth1/1"]},
+            ],
+        },
+    ]
+
+    for batch in batched(iter_interfaces(fabric_inventory), batch_size=2):
+        print("Processing batch:")
+        for item in batch:
+            print(f"  {item.datacenter}/{item.switch} -> {item.interface}")

--- a/examples/napalm_compliance.py
+++ b/examples/napalm_compliance.py
@@ -1,0 +1,37 @@
+"""NAPALM compliance workflow example."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from napalm import get_network_driver
+
+
+def load_candidate_config(hostname: str, username: str, password: str, candidate_path: Path) -> None:
+    """Connect to a device, load a config candidate, diff, and commit."""
+
+    driver = get_network_driver("nxos")
+    with driver(hostname, username, password) as device:
+        device.open()
+        device.load_merge_candidate(filename=str(candidate_path))
+        diff = device.compare_config()
+        if diff:
+            print(f"Diff for {hostname}:\n{diff}")
+            confirmation = input("Apply changes? [y/N]: ").strip().lower()
+            if confirmation == "y":
+                device.commit_config()
+                print("Committed")
+            else:
+                device.discard_config()
+                print("Discarded")
+        else:
+            print(f"No changes required on {hostname}")
+
+
+if __name__ == "__main__":
+    load_candidate_config(
+        hostname="leaf-1.example.com",
+        username="automation",
+        password="super-secret",
+        candidate_path=Path("configs/leaf-1_merge.txt"),
+    )

--- a/examples/nornir_threads.py
+++ b/examples/nornir_threads.py
@@ -1,0 +1,30 @@
+"""Example Nornir task for collecting NX-OS facts in parallel."""
+
+from __future__ import annotations
+
+from nornir import InitNornir
+from nornir.core.filter import F
+from nornir.core.task import Result, Task
+from nornir_napalm.plugins.tasks import napalm_get
+
+
+def collect_switch_facts(task: Task) -> Result:
+    """Fetch basic facts from a switch via NAPALM."""
+
+    response = task.run(task=napalm_get, getters=["facts", "interfaces"])
+    facts = response.result["facts"]
+    hostname = facts["hostname"]
+    serial = facts.get("serial_number", "unknown")
+    return Result(host=task.host, result={"hostname": hostname, "serial": serial})
+
+
+if __name__ == "__main__":
+    nr = InitNornir(config_file="config.yaml")
+
+    # Filter to only Nexus switches in the production group.
+    nexus = nr.filter(F(platform="nxos"), F(groups__contains="production"))
+
+    result = nexus.run(task=collect_switch_facts)
+    for host, host_result in result.items():
+        facts = host_result[0].result  # The first entry is the return value from collect_switch_facts
+        print(f"{host}: hostname={facts['hostname']} serial={facts['serial']}")

--- a/examples/pyats_example.py
+++ b/examples/pyats_example.py
@@ -1,0 +1,45 @@
+"""Minimal pyATS aetest script for NX-OS validation."""
+
+from __future__ import annotations
+
+from pyats import aetest
+from genie.testbed import load
+
+
+class CommonSetup(aetest.CommonSetup):
+    @aetest.subsection
+    def connect_to_devices(self, testbed):
+        self.parent.parameters.update(testbed=testbed)
+        for device in testbed:
+            device.connect(log_stdout=False)
+
+
+class VerifyInterfaceState(aetest.Testcase):
+    @aetest.setup
+    def load_testbed(self, testbed):
+        self.testbed = load(testbed) if isinstance(testbed, str) else testbed
+
+    @aetest.test
+    def check_interfaces(self):
+        for device in self.testbed:
+            parsed = device.parse("show interface status")
+            down_interfaces = [
+                name
+                for name, data in parsed.items()
+                if data.get("status") != "connected" and not name.startswith("mgmt")
+            ]
+            self.passed(f"{device.name}: all interfaces up") if not down_interfaces else self.failed(
+                f"{device.name}: down interfaces {down_interfaces}"
+            )
+
+
+class CommonCleanup(aetest.CommonCleanup):
+    @aetest.subsection
+    def disconnect(self, steps, testbed):
+        for device in testbed:
+            with steps.start(f"Disconnect {device.name}"):
+                device.disconnect()
+
+
+if __name__ == "__main__":
+    aetest.main(testbed="testbed.yaml")

--- a/examples/python_basics.py
+++ b/examples/python_basics.py
@@ -1,0 +1,72 @@
+"""Foundational Python patterns for network engineers.
+
+This module demonstrates:
+* Working with built-in data structures.
+* Iterating with loops and comprehensions.
+* Building reusable functions with type hints.
+* Using context managers to handle files safely.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(slots=True)
+class Interface:
+    """Simple representation of a network interface."""
+
+    name: str
+    enabled: bool
+    description: str | None = None
+
+
+def up_interface_names(interfaces: Iterable[Interface]) -> list[str]:
+    """Return the names of all enabled interfaces."""
+
+    return [iface.name for iface in interfaces if iface.enabled]
+
+
+def normalize_description(description: str | None) -> str:
+    """Return a cleaned description string suitable for configuration templates."""
+
+    if not description:
+        return "UNCONFIGURED"
+    return description.strip().upper()
+
+
+def summarize_interfaces(interfaces: Iterable[Interface]) -> dict[str, Any]:
+    """Summarize interface state for reporting or templating."""
+
+    interfaces = list(interfaces)
+    return {
+        "total": len(interfaces),
+        "enabled": len([iface for iface in interfaces if iface.enabled]),
+        "disabled": len([iface for iface in interfaces if not iface.enabled]),
+        "names": [iface.name for iface in interfaces],
+    }
+
+
+def save_report(path: str, summary: dict[str, Any]) -> None:
+    """Persist a JSON-like summary to disk using a context manager."""
+
+    lines = [f"{key}: {value}\n" for key, value in summary.items()]
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.writelines(lines)
+
+
+if __name__ == "__main__":
+    inventory = [
+        Interface(name="Eth1/1", enabled=True, description="Uplink to DC1"),
+        Interface(name="Eth1/2", enabled=False, description=None),
+        Interface(name="Eth1/3", enabled=True, description=" server-101 "),
+    ]
+
+    print("Enabled interfaces:", up_interface_names(inventory))
+    print("Normalized descriptions:", [normalize_description(i.description) for i in inventory])
+    summary = summarize_interfaces(inventory)
+    print("Summary:", summary)
+    save_report("interface_report.txt", summary)
+    print("Report written to interface_report.txt")

--- a/examples/vxlan_fabric_manager.py
+++ b/examples/vxlan_fabric_manager.py
@@ -1,0 +1,247 @@
+"""High-level VXLAN EVPN fabric manager.
+
+This module complements ``basic_vxlan_conf.py`` by adding:
+
+* service definitions (VRFs/VLANs/VNIs) that can be layered on top of the
+  baseline underlay deployment
+* parallel configuration pushes with robust exception handling
+* inventory loading from YAML/JSON to support production workflows
+
+Usage tips:
+    python vxlan_fabric_manager.py --inventory fabric.yml --services services.yml
+
+Both files are optional.  When omitted, the script falls back to the same sample
+inventory defined in ``basic_vxlan_conf`` so that you can experiment without
+needing any external data sources.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass
+from getpass import getpass
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+import yaml
+
+from basic_vxlan_conf import Device, DeviceRole, VXLANConfigurator
+
+# ---------------------------------------------------------------------------
+# Service definition models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VRFService:
+    """Describes a tenant VRF."""
+
+    name: str
+    vni: int
+    route_distinguisher: str
+    export_rt: str
+    import_rt: str
+
+
+@dataclass
+class VLANService:
+    """Describes a VLAN/VNI bridge domain."""
+
+    vlan_id: int
+    vni: int
+    description: str
+    vrf: str
+
+
+@dataclass
+class ServiceBundle:
+    """Collection of overlay services to deploy on a set of leaves."""
+
+    vrfs: List[VRFService]
+    vlans: List[VLANService]
+    target_roles: List[DeviceRole]
+
+
+# ---------------------------------------------------------------------------
+# Overlay extension logic
+# ---------------------------------------------------------------------------
+
+
+class ServiceAwareConfigurator(VXLANConfigurator):
+    """Extends the baseline configurator with overlay services."""
+
+    def __init__(
+        self,
+        devices: Iterable[Device],
+        services: Optional[ServiceBundle] = None,
+        fabric_name: str = "DC1",
+    ) -> None:
+        super().__init__(list(devices), fabric_name=fabric_name)
+        self.services = services
+
+    def build_overlay_config(self, device: Device) -> List[str]:  # type: ignore[override]
+        base_commands = super().build_overlay_config(device)
+        if not self.services or device.role not in self.services.target_roles:
+            return base_commands
+
+        commands = list(base_commands)
+        commands.extend(self._vrf_overlay(device))
+        commands.extend(self._vlan_overlay(device))
+        return commands
+
+    def _vrf_overlay(self, device: Device) -> List[str]:
+        commands: List[str] = []
+        for vrf in self.services.vrfs:
+            commands.extend(
+                [
+                    f"vrf context {vrf.name}",
+                    f"  rd {vrf.route_distinguisher}",
+                    f"  address-family ipv4 unicast",
+                    f"    route-target both {vrf.export_rt}",
+                    f"    route-target both {vrf.import_rt}",
+                    "    redistribute connected",
+                    "  exit",
+                    "exit",
+                    "router bgp 65000",
+                    "  address-family ipv4 unicast",
+                    f"    vrf {vrf.name}",
+                    "      advertise l2vpn evpn",
+                    "    exit",
+                    "  exit",
+                    "exit",
+                ]
+            )
+        return commands
+
+    def _vlan_overlay(self, device: Device) -> List[str]:
+        commands: List[str] = []
+        for vlan in self.services.vlans:
+            commands.extend(
+                [
+                    f"vlan {vlan.vlan_id}",
+                    f"  name {vlan.description}",
+                    "exit",
+                    f"vlan configuration {vlan.vlan_id}",
+                    f"  member vni {vlan.vni}",
+                    "exit",
+                    f"interface nve1",
+                    f"  member vni {vlan.vni}",
+                    "    suppress-arp",
+                    "    ingress-replication protocol bgp",
+                    "  exit",
+                    "exit",
+                    f"interface vlan {vlan.vlan_id}",
+                    f"  description {vlan.description}",
+                    f"  vrf member {vlan.vrf}",
+                    "  no shutdown",
+                    "exit",
+                ]
+            )
+        return commands
+
+
+# ---------------------------------------------------------------------------
+# Inventory parsing helpers
+# ---------------------------------------------------------------------------
+
+
+def load_devices_from_file(path: Optional[Path]) -> List[Device]:
+    if not path:
+        return []
+
+    if path.suffix in {".yml", ".yaml"}:
+        data = yaml.safe_load(path.read_text())
+    elif path.suffix == ".json":
+        data = json.loads(path.read_text())
+    else:
+        raise ValueError("Unsupported inventory format. Use YAML or JSON.")
+
+    devices = []
+    for entry in data.get("devices", []):
+        devices.append(
+            Device(
+                name=entry["name"],
+                role=DeviceRole(entry["role"]),
+                host=entry["host"],
+                loopback_base=entry.get("loopback_base", data.get("loopback_base", "10.255.0.0/24")),
+                vpc_pair=entry.get("vpc_pair"),
+                asn=entry.get("asn"),
+                tags=tuple(entry.get("tags", [])),
+                metadata=entry.get("metadata", {}),
+            )
+        )
+    return devices
+
+
+def load_services_from_file(path: Optional[Path]) -> Optional[ServiceBundle]:
+    if not path:
+        return None
+
+    data = yaml.safe_load(path.read_text())
+    vrfs = [
+        VRFService(
+            name=entry["name"],
+            vni=entry["vni"],
+            route_distinguisher=entry["rd"],
+            export_rt=entry["export_rt"],
+            import_rt=entry["import_rt"],
+        )
+        for entry in data.get("vrfs", [])
+    ]
+    vlans = [
+        VLANService(
+            vlan_id=entry["vlan_id"],
+            vni=entry["vni"],
+            description=entry.get("description", f"VLAN{entry['vlan_id']}"),
+            vrf=entry["vrf"],
+        )
+        for entry in data.get("vlans", [])
+    ]
+    target_roles = [DeviceRole(role) for role in data.get("target_roles", ["leaf", "border_leaf"])]
+    return ServiceBundle(vrfs=vrfs, vlans=vlans, target_roles=target_roles)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Deploy VXLAN EVPN services")
+    parser.add_argument("--inventory", type=Path, help="Path to YAML/JSON inventory", default=None)
+    parser.add_argument("--services", type=Path, help="Path to services YAML", default=None)
+    parser.add_argument("--fabric-name", default="DC1")
+    args = parser.parse_args()
+
+    devices = load_devices_from_file(args.inventory)
+    if not devices:
+        from basic_vxlan_conf import build_sample_inventory
+
+        loopback_subnet = input("Loopback supernet for automation [10.255.0.0/24]: ").strip() or "10.255.0.0/24"
+        devices = build_sample_inventory(loopback_subnet)
+
+    services = load_services_from_file(args.services)
+    configurator = ServiceAwareConfigurator(devices, services=services, fabric_name=args.fabric_name)
+
+    username = input("Username: ")
+    password = getpass("Password: ")
+
+    print("Starting deployment...\n")
+    with ThreadPoolExecutor(max_workers=min(8, len(configurator.devices))) as executor:
+        future_map = {
+            executor.submit(configurator.push_config, device, username, password): device
+            for device in configurator.devices
+        }
+
+        for future in as_completed(future_map):
+            device = future_map[future]
+            try:
+                future.result()
+                print(f"✔ Successfully configured {device.name}")
+            except Exception as exc:  # pylint: disable=broad-except
+                print(f"✖ Failed to configure {device.name}: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples_using_jinja/README.md
+++ b/examples_using_jinja/README.md
@@ -1,0 +1,78 @@
+# Jinja-Driven VXLAN EVPN Bootstrap Examples
+
+This directory mirrors the structure of the `examples/` folder but focuses on
+**template-based automation**. Each script is saturated with comments so that a
+beginner can understand the purpose of every section before adapting it to a
+production fabric.
+
+## Why Jinja?
+
+* **Consistency** – The template enforces identical configuration blocks across
+your fabric which prevents drift.
+* **Speed** – Adding a new switch type often becomes a matter of extending the
+JSON data instead of writing new Python logic.
+* **Modularity** – Business intent (the JSON file) lives separately from the
+rendering logic which makes code reviews and change control easier.
+
+There are still times where generating commands programmatically in Python is
+useful (for example, when you need to react to telemetry or device state in
+real time). Jinja excels when you know the desired configuration up-front and
+want to stamp it out in a deterministic way.
+
+## Repository Contents
+
+| File | Description |
+| ---- | ----------- |
+| `fabric_variables.json` | Declarative source of truth for fabric attributes such as device roles, loopback IDs, vPC domains, multicast group, and BGP ASN. |
+| `templates/device_full_config.j2` | Production-ready configuration template. Feature enablement, underlay, and overlay blocks are rendered conditionally based on device role. |
+| `render_fabric_configs.py` | Offline helper that renders per-switch configuration files into `rendered-configs/`. Useful for design reviews or uploading into Git for change control. |
+| `deploy_fabric_configs.py` | Netmiko-powered workflow that renders the template and pushes it to Nexus switches with a mandatory diff/confirm step. |
+
+Feel free to duplicate the template or add new ones (for example, a dedicated
+underlay template) and swap them in by name when rendering. Jinja is flexible
+and you can even call multiple templates in a single Python script to compose a
+final configuration.
+
+## JSON vs. YAML vs. Spreadsheet
+
+JSON is used here because it is easy to read, version, and parse with the
+standard library. If your team already tracks fabric details in a spreadsheet,
+export it to JSON/CSV and convert on the fly. YAML is equally valid—simply swap
+`json.load` for `yaml.safe_load` (after installing PyYAML) if you prefer the
+syntax. The key point is to keep the source of truth outside of your Python so
+changes can be reviewed without digging through code diffs.
+
+## Operational Workflow
+
+1. Update `fabric_variables.json` with the new switch or feature details.
+2. Run `python render_fabric_configs.py` to create candidate configs.
+3. Review the generated files (`rendered-configs/<hostname>.cfg`).
+4. When ready, execute `python deploy_fabric_configs.py`, supply your
+   credentials, inspect the diff, and explicitly approve the commit.
+5. Archive the rendered configs in Git to create a rollback point. If you need
+   to undo a change, simply re-render the last known-good JSON and push it.
+
+## Extending the Template
+
+* To add **new features** (for example, telemetry streaming or additional VRFs),
+  extend the JSON with the required metadata and update `device_full_config.j2`.
+* For **role-specific changes** (like unique feature sets on border gateways),
+  add new conditionals in the template or break the template into smaller files
+  and include them dynamically.
+* If you grow beyond JSON, consider plugging these scripts into **Nornir** so
+you can parallelize deployments and tie into inventory plugins you already use.
+
+## Dependencies
+
+* Python 3.9+
+* `jinja2`
+* `netmiko`
+
+Install them with:
+
+```bash
+pip install jinja2 netmiko
+```
+
+Running inside a virtual environment is strongly recommended to keep packages
+isolated from the system Python.

--- a/examples_using_jinja/deploy_fabric_configs.py
+++ b/examples_using_jinja/deploy_fabric_configs.py
@@ -1,0 +1,146 @@
+"""Connect to Nexus switches and push Jinja-rendered configurations.
+
+The structure mirrors ``render_fabric_configs.py`` but adds the device
+connection workflow. The script renders the configuration in-memory and then
+uses Netmiko to stage the config as a candidate, show a diff, and optionally
+commit it. Keeping rendering and deployment in separate functions makes it easy
+for you to plug these helpers into larger frameworks such as Nornir.
+"""
+from __future__ import annotations
+
+import json
+from getpass import getpass
+from ipaddress import ip_network
+from pathlib import Path
+from typing import Dict, Iterable
+
+from jinja2 import Environment, FileSystemLoader
+from netmiko import ConnectHandler
+
+
+# -----------------------------------------------------------------------------
+# Data loading helpers (identical to the render script)
+# -----------------------------------------------------------------------------
+
+def load_fabric_variables(variables_file: Path) -> Dict:
+    with variables_file.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def calculate_loopback_ip(prefix: str, loopback_id: int) -> str:
+    network = ip_network(prefix)
+    host = network.network_address + loopback_id
+    return str(host)
+
+
+def enrich_devices(fabric: Dict) -> Iterable[Dict]:
+    devices = fabric["devices"]
+    loopback_prefix = fabric["loopback_prefix"]
+    index = {device["name"]: device for device in devices}
+    used_vpc_domains = {}
+
+    for device in devices:
+        device["loopback_ip"] = calculate_loopback_ip(loopback_prefix, device["loopback_id"])
+
+        if device["role"] == "spine":
+            device["downlinks"] = [
+                {
+                    "name": peer["name"],
+                    "ip": calculate_loopback_ip(loopback_prefix, peer["loopback_id"]),
+                }
+                for peer in devices
+                if peer["role"] != "spine"
+            ]
+
+        if device.get("vpc"):
+            peer_name = device["vpc"]["peer"]
+            peer = index.get(peer_name)
+            if not peer:
+                raise ValueError(f"vPC peer {peer_name} for {device['name']} not found")
+
+            domain_id = device["vpc"]["domain_id"]
+            owners = used_vpc_domains.setdefault(domain_id, set())
+            owners.add(device["name"])
+            if len(owners) > 2:
+                raise ValueError(
+                    f"vPC domain {domain_id} used by more than two switches: {owners}"
+                )
+
+            device["vpc_peer_mgmt_ip"] = peer["mgmt_ip"]
+            device["vpc_role_priority"] = 10 if device["name"].endswith("1") else 20
+
+        yield device
+
+
+# -----------------------------------------------------------------------------
+# Rendering helper
+# -----------------------------------------------------------------------------
+
+def render_device_config(environment: Environment, fabric: Dict, device: Dict) -> str:
+    template = environment.get_template("device_full_config.j2")
+    return template.render(
+        fabric_name=fabric["fabric_name"],
+        multicast_group=fabric["multicast_group"],
+        bgp_asn=fabric["bgp_asn"],
+        evpn_rrs=fabric["evpn_rrs"],
+        device=device,
+    )
+
+
+# -----------------------------------------------------------------------------
+# Netmiko workflow
+# -----------------------------------------------------------------------------
+
+def connect_and_push(device: Dict, config: str, username: str, password: str) -> None:
+    """Open an SSH session, preview the change, and commit on confirmation."""
+
+    # Netmiko uses a dictionary of connection parameters. Keeping the mapping in
+    # code helps beginners understand the expected keys and values.
+    connection_params = {
+        "device_type": "cisco_nxos",
+        "host": device["mgmt_ip"],
+        "username": username,
+        "password": password,
+        "fast_cli": False,
+    }
+
+    print(f"\nConnecting to {device['name']} ({device['mgmt_ip']}) ...")
+    with ConnectHandler(**connection_params) as conn:
+        print("Entering configuration session and loading candidate config ...")
+        conn.config_mode()
+        conn.send_config_set(config.splitlines(), enter_config_mode=False, exit_config_mode=False)
+
+        print("\nProposed changes (show diff) ->")
+        diff_output = conn.send_command("show diff")
+        print(diff_output)
+
+        apply = input("Commit changes to device? [yes/no]: ").strip().lower()
+        if apply in {"yes", "y"}:
+            print("Committing configuration ...")
+            conn.exit_config_mode()
+            conn.save_config()
+            print("Configuration committed and saved.")
+        else:
+            print("Discarding staged configuration ...")
+            conn.send_command_timing("abort", strip_prompt=False, strip_command=False)
+            conn.exit_config_mode()
+            print("Staged configuration removed. No changes were made.")
+
+
+def main() -> None:
+    variables_path = Path(__file__).with_name("fabric_variables.json")
+    template_dir = Path(__file__).with_name("templates")
+
+    fabric = load_fabric_variables(variables_path)
+    environment = Environment(loader=FileSystemLoader(template_dir))
+
+    username = input("Username: ")
+    password = getpass("Password: ")
+
+    for device in enrich_devices(fabric):
+        config = render_device_config(environment, fabric, device)
+        connect_and_push(device, config, username, password)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples_using_jinja/fabric_variables.json
+++ b/examples_using_jinja/fabric_variables.json
@@ -1,0 +1,110 @@
+{
+  "fabric_name": "dc1_vxlan_evpn",
+  "bgp_asn": 65001,
+  "evpn_rrs": ["spine01", "spine02"],
+  "multicast_group": "239.1.1.1",
+  "loopback_prefix": "10.255.0.0/24",
+  "devices": [
+    {
+      "name": "leaf01",
+      "role": "leaf",
+      "mgmt_ip": "10.0.0.11",
+      "loopback_id": 1,
+      "uplinks": [
+        {"interface": "Ethernet1/1", "peer": "spine01", "peer_interface": "Ethernet1/1"},
+        {"interface": "Ethernet1/2", "peer": "spine02", "peer_interface": "Ethernet1/2"}
+      ],
+      "access_ports": [
+        {"interface": "Ethernet1/10", "description": "ServerA"}
+      ],
+      "vpc": {
+        "domain_id": 10,
+        "peer": "leaf02"
+      }
+    },
+    {
+      "name": "leaf02",
+      "role": "leaf",
+      "mgmt_ip": "10.0.0.12",
+      "loopback_id": 2,
+      "uplinks": [
+        {"interface": "Ethernet1/1", "peer": "spine01", "peer_interface": "Ethernet1/3"},
+        {"interface": "Ethernet1/2", "peer": "spine02", "peer_interface": "Ethernet1/4"}
+      ],
+      "access_ports": [
+        {"interface": "Ethernet1/10", "description": "ServerB"}
+      ],
+      "vpc": {
+        "domain_id": 10,
+        "peer": "leaf01"
+      }
+    },
+    {
+      "name": "spine01",
+      "role": "spine",
+      "mgmt_ip": "10.0.0.21",
+      "loopback_id": 101,
+      "uplinks": [
+        {"interface": "Ethernet1/1", "peer": "leaf01", "peer_interface": "Ethernet1/1"},
+        {"interface": "Ethernet1/3", "peer": "leaf02", "peer_interface": "Ethernet1/1"}
+      ]
+    },
+    {
+      "name": "spine02",
+      "role": "spine",
+      "mgmt_ip": "10.0.0.22",
+      "loopback_id": 102,
+      "uplinks": [
+        {"interface": "Ethernet1/2", "peer": "leaf01", "peer_interface": "Ethernet1/2"},
+        {"interface": "Ethernet1/4", "peer": "leaf02", "peer_interface": "Ethernet1/2"}
+      ]
+    },
+    {
+      "name": "border_leaf01",
+      "role": "border_leaf",
+      "mgmt_ip": "10.0.0.31",
+      "loopback_id": 201,
+      "uplinks": [
+        {"interface": "Ethernet1/1", "peer": "spine01", "peer_interface": "Ethernet1/5"},
+        {"interface": "Ethernet1/2", "peer": "spine02", "peer_interface": "Ethernet1/5"}
+      ],
+      "external": [
+        {"interface": "Ethernet1/48", "description": "Edge-Router-1"}
+      ],
+      "vpc": {
+        "domain_id": 101,
+        "peer": "border_leaf02"
+      }
+    },
+    {
+      "name": "border_leaf02",
+      "role": "border_leaf",
+      "mgmt_ip": "10.0.0.32",
+      "loopback_id": 202,
+      "uplinks": [
+        {"interface": "Ethernet1/1", "peer": "spine01", "peer_interface": "Ethernet1/6"},
+        {"interface": "Ethernet1/2", "peer": "spine02", "peer_interface": "Ethernet1/6"}
+      ],
+      "external": [
+        {"interface": "Ethernet1/48", "description": "Edge-Router-2"}
+      ],
+      "vpc": {
+        "domain_id": 101,
+        "peer": "border_leaf01"
+      }
+    },
+    {
+      "name": "border_gateway01",
+      "role": "border_gateway",
+      "mgmt_ip": "10.0.0.41",
+      "loopback_id": 301,
+      "uplinks": [
+        {"interface": "Ethernet1/1", "peer": "spine01", "peer_interface": "Ethernet1/7"},
+        {"interface": "Ethernet1/2", "peer": "spine02", "peer_interface": "Ethernet1/7"}
+      ],
+      "external": [
+        {"interface": "Ethernet1/49", "description": "WAN-Router"}
+      ]
+    }
+  ]
+}

--- a/examples_using_jinja/render_fabric_configs.py
+++ b/examples_using_jinja/render_fabric_configs.py
@@ -1,0 +1,138 @@
+"""Render baseline VXLAN EVPN configurations with Jinja2.
+
+This script is intentionally verbose and heavily commented so that engineers who
+are new to Python can follow the flow and reuse the structure in their own
+projects. The goal is to take structured data (a JSON inventory) and feed it
+into a Jinja template so we receive consistent, production-ready configs for
+all node roles (leaf, spine, border leaf, and border gateway).
+
+The script only renders configuration files to disk; it never touches a
+physical device. Use ``deploy_fabric_configs.py`` if you want to connect to the
+switches and push the configuration.
+"""
+from __future__ import annotations
+
+import json
+from ipaddress import ip_network
+from pathlib import Path
+from typing import Dict, List
+
+from jinja2 import Environment, FileSystemLoader
+
+# -----------------------------------------------------------------------------
+# Helper functions
+# -----------------------------------------------------------------------------
+
+def load_fabric_variables(variables_file: Path) -> Dict:
+    """Return the structured data we maintain in ``fabric_variables.json``.
+
+    Keeping the details in JSON decouples data from code so we can version the
+    business intent (loopback prefix, role assignments, multicast group, and so
+    on) independently from the Python logic. Any automation platform—Python or
+    otherwise—can parse JSON, which makes this format future proof.
+    """
+
+    with variables_file.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def calculate_loopback_ip(prefix: str, loopback_id: int) -> str:
+    """Derive a /32 loopback address from the shared prefix and host ID.
+
+    The JSON file contains a ``loopback_id`` for every node. We add that value
+    to the network address of the prefix to deterministically produce the
+    per-device loopback. This keeps things simple: leaf01 uses ID 1, leaf02 uses
+    ID 2, border leafs start at 201, and border gateways start at 301. If you
+    prefer a different scheme, just adjust the numbers in the JSON file.
+    """
+
+    network = ip_network(prefix)
+    host = network.network_address + loopback_id
+    return str(host)
+
+
+def enrich_devices(fabric: Dict) -> List[Dict]:
+    """Attach computed values and validation data to every device entry."""
+
+    devices = fabric["devices"]
+    loopback_prefix = fabric["loopback_prefix"]
+
+    # Build an index by hostname so we can look up peers quickly later on.
+    index = {device["name"]: device for device in devices}
+
+    # Track vPC domain IDs to guard against duplicates.
+    vpc_domain_tracker = {}
+
+    for device in devices:
+        device["loopback_ip"] = calculate_loopback_ip(loopback_prefix, device["loopback_id"])
+
+        # Attach downlink metadata that the Jinja template expects for spines.
+        if device["role"] == "spine":
+            device["downlinks"] = [
+                {
+                    "name": peer["name"],
+                    "ip": calculate_loopback_ip(loopback_prefix, peer["loopback_id"]),
+                }
+                for peer in devices
+                if peer["role"] != "spine"
+            ]
+
+        # When a device participates in a vPC we use the index to fetch details
+        # about the peer. These additional fields help the template render
+        # peer-keepalive and deterministic role priorities.
+        if device.get("vpc"):
+            peer_name = device["vpc"]["peer"]
+            peer = index.get(peer_name)
+            if not peer:
+                raise ValueError(f"vPC peer {peer_name} for {device['name']} not found")
+
+            # ``setdefault`` initializes the set only once. We then raise an
+            # exception if two different pairs try to reuse the same domain ID.
+            domain_id = device["vpc"]["domain_id"]
+            owners = vpc_domain_tracker.setdefault(domain_id, set())
+            owners.add(device["name"])
+            if len(owners) > 2:
+                raise ValueError(
+                    f"vPC domain {domain_id} used by more than two switches: {owners}"
+                )
+
+            device["vpc_peer_mgmt_ip"] = peer["mgmt_ip"]
+            # Lower priority wins the primary role; odd/even split keeps it easy.
+            device["vpc_role_priority"] = 10 if device["name"].endswith("1") else 20
+
+    return devices
+
+
+def render_configs() -> None:
+    """Generate per-device configuration files under ``rendered-configs``."""
+
+    variables_path = Path(__file__).with_name("fabric_variables.json")
+    fabric = load_fabric_variables(variables_path)
+    devices = enrich_devices(fabric)
+
+    output_dir = Path(__file__).with_name("rendered-configs")
+    output_dir.mkdir(exist_ok=True)
+
+    # Jinja needs to know where the template files live. ``FileSystemLoader``
+    # points to the ``templates`` directory alongside this script.
+    environment = Environment(loader=FileSystemLoader(Path(__file__).with_name("templates")))
+    template = environment.get_template("device_full_config.j2")
+
+    for device in devices:
+        rendered = template.render(
+            fabric_name=fabric["fabric_name"],
+            multicast_group=fabric["multicast_group"],
+            bgp_asn=fabric["bgp_asn"],
+            evpn_rrs=fabric["evpn_rrs"],
+            device=device,
+        )
+
+        filename = output_dir / f"{device['name']}.cfg"
+        with filename.open("w", encoding="utf-8") as handle:
+            handle.write(rendered)
+
+        print(f"Rendered configuration for {device['name']} -> {filename}")
+
+
+if __name__ == "__main__":
+    render_configs()

--- a/examples_using_jinja/templates/device_full_config.j2
+++ b/examples_using_jinja/templates/device_full_config.j2
@@ -1,0 +1,132 @@
+{#
+  Jinja2 template that creates a production-ready bootstrap configuration
+  for a Nexus VXLAN EVPN device. The Python script feeds role specific
+  variables so we can keep logic here minimal. Jinja comments like this one
+  are stripped from the rendered output.
+#}
+!
+hostname {{ device.name }}
+!
+interface loopback0
+  description *** VXLAN Loopback for {{ fabric_name }} ***
+  ip address {{ device.loopback_ip }} 255.255.255.255
+!
+{% if device.role in ["leaf", "border_leaf", "border_gateway"] %}
+feature interface-vlan
+feature vn-segment-vlan-based
+feature nv overlay
+feature ospf
+feature bgp
+feature pim
+feature lacp
+feature vpc
+feature dhcp
+feature telemetry
+{% elif device.role == "spine" %}
+feature ospf
+feature bgp
+feature pim
+feature telemetry
+{% endif %}
+!
+vrf context management
+  ip route 0.0.0.0/0 {{ device.default_route | default('10.0.0.1') }}
+!
+{% if device.role in ["leaf", "border_leaf", "border_gateway"] %}
+interface nve1
+  no shutdown
+  source-interface loopback0
+  host-reachability protocol bgp
+  member vni 0-16777215 ingress-replication
+    protocol bgp
+  mcast-group {{ multicast_group }}
+{% endif %}
+!
+router ospf UNDERLAY
+  router-id {{ device.loopback_ip }}
+  log-adjacency-changes detail
+{% for link in device.uplinks %}
+interface {{ link.interface }}
+  description *** to {{ link.peer }} {{ link.peer_interface }} ***
+  no switchport
+  ip unnumbered loopback0
+  ip router ospf UNDERLAY area 0.0.0.0
+{% if link.get('bfd', true) %}  ip ospf bfd{% endif %}
+  no shutdown
+{% endfor %}
+!
+router bgp {{ bgp_asn }}
+  router-id {{ device.loopback_ip }}
+  address-family ipv4 unicast
+    maximum-paths 4
+{% if device.role == "spine" %}
+  template peer LEAFS
+    remote-as {{ bgp_asn }}
+    update-source loopback0
+  address-family l2vpn evpn
+    retain route-target all
+{% for neighbor in device.downlinks %}
+  neighbor {{ neighbor.ip }}
+    inherit peer LEAFS
+    description *** to {{ neighbor.name }} ***
+{% endfor %}
+{% else %}
+  template peer SPINES
+    remote-as {{ bgp_asn }}
+    update-source loopback0
+  address-family l2vpn evpn
+    advertise-all-vni
+    retain route-target all
+{% for rr in evpn_rrs %}
+  neighbor {{ rr }}
+    inherit peer SPINES
+    description *** EVPN RR {{ rr }} ***
+    address-family l2vpn evpn
+{% endfor %}
+{% endif %}
+!
+{% if device.role in ["leaf", "border_leaf", "border_gateway"] and device.get('vpc') %}
+vpc domain {{ device.vpc.domain_id }}
+  peer-keepalive destination {{ device.vpc_peer_mgmt_ip }} source {{ device.mgmt_ip }}
+  system-priority 32000
+  role priority {{ device.vpc_role_priority }}
+  peer-gateway
+  ip arp synchronize
+  auto-recovery reload-delay 240
+  graceful-consistency-check
+{% endif %}
+!
+{% if device.get('access_ports') %}
+{% for access in device.access_ports %}
+interface {{ access.interface }}
+  description *** {{ access.description }} ***
+  switchport
+  switchport mode trunk
+  spanning-tree port type edge trunk
+  mtu 9216
+  no shutdown
+{% endfor %}
+{% endif %}
+!
+{% if device.get('external') %}
+{% for ext in device.external %}
+interface {{ ext.interface }}
+  description *** {{ ext.description }} ***
+  no switchport
+  ip address dhcp
+  no shutdown
+{% endfor %}
+{% endif %}
+!
+{% if device.role in ["border_leaf", "border_gateway"] %}
+router bgp {{ bgp_asn }}
+  vrf INTERNET
+    address-family ipv4 unicast
+      redistribute connected
+{% endif %}
+!
+line console
+  exec-timeout 15
+  logging synchronous
+!
+end


### PR DESCRIPTION
## Summary
- replace the placeholder README with a detailed Python automation playbook for NX-OS engineers
- add runnable example scripts covering Python fundamentals, looping strategies, concurrency, Nornir, NAPALM, and pyATS usage
- add a `.gitignore` to exclude Python bytecode artifacts

## Testing
- python examples/python_basics.py
- python examples/functions_vs_classes.py

------
https://chatgpt.com/codex/tasks/task_e_690b45ff60888324bb5663c869d0da00