### PR TITLE
Add FRR DC VXLAN EVPN containerlab lab with spine/leaf fabric, firewall, and clients

### DIFF
--- a/Introduction.md
+++ b/Introduction.md
@@ -1,0 +1,263 @@
+# Introduction to this FRR DC VXLAN EVPN Lab (Beginner Friendly)
+
+This document explains the lab in simple terms and focuses on:
+
+- what VXLAN EVPN is,
+- how traffic moves in this topology,
+- who is the gateway for clients,
+- why default routes exist in both VRFs,
+- and exactly how to troubleshoot routing/VRFs/learned paths.
+
+---
+
+## 1) What this lab is trying to teach
+
+This project simulates a **small data-center fabric** using FRR routers in containerlab:
+
+- 2 Spines
+- 3 Leaves
+- 1 Edge router (simulated “internet” by advertising `8.8.8.8/32`)
+- 1 Firewall (FRR + iptables)
+- 2 Clients
+
+You can test:
+
+1. Underlay routing (spine-leaf reachability)
+2. EVPN control plane between leaves and spines
+3. Per-VRF service routing (Blue and Red)
+4. Firewall policy/NAT as north-south gateway
+5. Internet path simulation to `8.8.8.8`
+
+---
+
+## 2) Quick VXLAN EVPN explanation (simple)
+
+Think of it as two layers:
+
+### Underlay (transport network)
+- This is the IP network between spines and leaves.
+- In this lab, underlay uses eBGP between spines and leaves.
+- Its job: make sure all fabric nodes can reach each other.
+
+### Overlay (service/network virtualization)
+- This is where tenant/service networks are represented (Blue/Red VRFs + VNIs).
+- EVPN (using BGP) distributes route information for those VRFs.
+- Its job: make separate logical networks behave consistently across leaves.
+
+In short:
+- **Underlay carries packets between routers**.
+- **Overlay decides which tenant/service route belongs where**.
+
+---
+
+## 3) Who is the gateway for clients?
+
+In this design, the **firewall (`fw1`) is the service gateway** toward external networks.
+
+- Client1 belongs to Blue side.
+- Client2 belongs to Red side.
+- Leaf routers provide the first routed hop from client links.
+- Firewall is connected with dedicated L3 transit links per VRF:
+  - Blue transit: `leaf1 <-> fw1` (`172.16.10.0/31`)
+  - Red transit: `leaf1 <-> fw1` (`172.16.20.0/31`)
+- Firewall also has an outside link toward leaf1 (`172.31.0.4/31` side on leaf1, `172.31.0.5/31` on fw1), then leaf1 reaches edge1 (`172.31.0.0/31`) where `8.8.8.8/32` is advertised.
+
+So operationally:
+- **Default route for Blue/Red services is learned from firewall** (BGP default-originate on fw1 per VRF).
+- Firewall then forwards/NATs traffic toward outside.
+
+---
+
+## 4) “How do clients know to go to firewall for other subnets?”
+
+Great question. Routers and hosts do this based on routing tables:
+
+1. A client compares destination IP with its directly connected subnet.
+2. If destination is not local, it uses its default route.
+3. Its upstream leaf receives traffic and looks up route in the relevant VRF.
+4. If destination is external/unknown tenant subnet, leaf uses **default route learned from firewall**.
+5. Firewall applies policy/NAT and forwards toward outside network.
+
+So clients do not “know firewall directly” in all cases; they know **their next-hop/gateway path**. The leaf and VRF routing logic then steers traffic to firewall for non-local destinations.
+
+---
+
+## 5) Why is default route advertised in both VRFs?
+
+Because Blue and Red are separate routing domains.
+
+- `router bgp ... vrf blue` has `default-originate` toward leaf
+- `router bgp ... vrf red` has `default-originate` toward leaf
+
+This means each VRF gets its own `0.0.0.0/0`, allowing both service domains to reach external destinations via firewall.
+
+Without this, one (or both) VRFs might have no path to internet or external prefixes.
+
+---
+
+## 6) How to troubleshoot step-by-step
+
+## A. Check lab/container state
+
+```bash
+containerlab inspect -t frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml
+```
+
+Verify all nodes are in `running` state.
+
+---
+
+## B. Check VRFs on a node
+
+### Linux VRF view (kernel side)
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 ip -d link show type vrf
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 ip -d link show type vrf
+```
+
+### FRR view (routing side)
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show vrf'
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 vtysh -c 'show vrf'
+```
+
+---
+
+## C. Check BGP sessions
+
+### Underlay BGP
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-spine1 vtysh -c 'show bgp summary'
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp summary'
+```
+
+### EVPN control plane
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp l2vpn evpn summary'
+```
+
+### Per-VRF BGP neighbors/routes
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp vrf blue ipv4 summary'
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp vrf red ipv4 summary'
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 vtysh -c 'show bgp vrf blue ipv4 summary'
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 vtysh -c 'show bgp vrf red ipv4 summary'
+```
+
+---
+
+## D. See routes inside each VRF
+
+### Kernel/FIB routes per VRF
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 ip route show vrf blue
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 ip route show vrf red
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 ip route show vrf blue
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 ip route show vrf red
+```
+
+### FRR RIB routes per VRF
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show ip route vrf blue'
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show ip route vrf red'
+```
+
+---
+
+## E. “From where did this IP route get learned?”
+
+Use these commands:
+
+```bash
+# Specific prefix in VRF Blue
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp vrf blue ipv4 0.0.0.0/0'
+
+# Specific host route example
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp vrf blue ipv4 8.8.8.8/32'
+
+# Full table with next-hops and path attributes
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp vrf blue ipv4'
+```
+
+What to look for:
+- **Next hop** (who sent it / where traffic goes)
+- **Path attributes** (AS path, local-pref, MED)
+- **Best path marker (`*>`)**
+- **Installed in FIB** indicator
+
+If a route is in BGP but not in kernel route table, check policy/filtering/next-hop reachability.
+
+---
+
+## F. Validate data-plane with ping/traceroute
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-client1 ping -c 3 172.16.10.1
+docker exec -it clab-frr-dc-vxlan-evpn-client2 ping -c 3 172.16.20.1
+docker exec -it clab-frr-dc-vxlan-evpn-client1 ping -c 3 8.8.8.8
+docker exec -it clab-frr-dc-vxlan-evpn-client2 ping -c 3 8.8.8.8
+
+docker exec -it clab-frr-dc-vxlan-evpn-client1 traceroute 8.8.8.8
+docker exec -it clab-frr-dc-vxlan-evpn-client2 traceroute 8.8.8.8
+```
+
+---
+
+## G. Check firewall rules and counters
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 iptables -S
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 iptables -t nat -S
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 iptables -L -n -v
+```
+
+Counters increasing on expected rules confirm real forwarding/NAT path.
+
+---
+
+## 7) Common issues and what they usually mean
+
+- **BGP neighbor stuck in Active/Connect**
+  - Interface IP mismatch, wrong AS, link down, or daemon not up.
+
+- **Route present in BGP but traffic still fails**
+  - Missing kernel route install, policy/iptables block, missing return path.
+
+- **Can ping firewall transit but not 8.8.8.8**
+  - Check default route propagation, edge route advertisement, NAT rules.
+
+- **One VRF works, other fails**
+  - Usually per-VRF BGP neighbor/default-originate mismatch.
+
+---
+
+## 8) How to safely extend this lab
+
+1. Add/modify firewall policy in:
+   - `frr-dc-vxlan-evpn/firewall/iptables.rules.v4`
+2. Re-apply quickly:
+   ```bash
+   docker exec -i clab-frr-dc-vxlan-evpn-fw1 iptables-restore < frr-dc-vxlan-evpn/firewall/iptables.rules.v4
+   ```
+3. Add more clients by:
+   - creating new link(s) in topology,
+   - adding FRR config with per-VRF BGP or static routes,
+   - validating with `show ip route vrf <name>` and ping/traceroute.
+
+---
+
+## 9) Mental model (easy memory)
+
+- **Leafs = fabric access + tenant routing context**
+- **Spines = transport core + EVPN control reflection**
+- **Firewall = policy/NAT internet gateway for Blue/Red VRFs**
+- **Edge = fake internet endpoint (`8.8.8.8`)**
+
+If you remember this flow, troubleshooting becomes much easier.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,149 @@
-# codex_ai
+# FRR DC VXLAN EVPN (containerlab)
+
+This repository contains a ready-to-use **containerlab** project for a small data-center fabric built with **FRR**:
+
+- 2x Spine routers (FRR)
+- 3x Leaf routers (FRR)
+- 1x Edge router (FRR) simulating internet reachability to `8.8.8.8`
+- 1x Firewall node (FRR + iptables)
+- 2x L3 clients in different service domains (Blue/Red)
+- Client1 is dual-homed to two different leaves for ECMP-style upstream redundancy
+
+## Topology Overview
+
+Project path:
+
+- `frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml`
+
+High-level design:
+
+1. **Underlay:** eBGP between Spines and Leaves
+2. **Overlay:** EVPN control-plane signaling from Leaves through Spine route-reflectors
+3. **Service Segments:** Blue and Red VRF-oriented routing model on Leaves/Firewall
+4. **Internet Simulation:** `edge1` advertises `8.8.8.8/32`
+5. **Firewall:** policy control and NAT via `iptables.rules.v4`
+
+## Directory Layout
+
+```text
+frr-dc-vxlan-evpn/
+├── topology/
+│   └── clab-frr-dc-vxlan-evpn.yml
+├── configs/
+│   ├── spine1/frr.conf
+│   ├── spine2/frr.conf
+│   ├── leaf1/frr.conf
+│   ├── leaf2/frr.conf
+│   ├── leaf3/frr.conf
+│   ├── edge1/frr.conf
+│   ├── fw1/frr.conf
+│   ├── client1/frr.conf
+│   └── client2/frr.conf
+├── firewall/
+│   └── iptables.rules.v4
+└── scripts/
+    ├── setup-leaf-vrfs.sh
+    └── setup-firewall.sh
+```
+
+## Addressing and Roles
+
+- Underlay links: `10.0.0.0/31` blocks between spines and leaves
+- Loopbacks:
+  - Spines: `10.255.0.1/32`, `10.255.0.2/32`
+  - Leaves: `10.255.1.1/32` .. `10.255.1.3/32`
+- Internet simulator on edge: loopback `8.8.8.8/32`
+- Firewall transit links:
+  - Blue VRF transit: `172.16.10.0/31`
+  - Red VRF transit: `172.16.20.0/31`
+  - Outside transit: `172.31.0.4/31`
+- Client links:
+  - Client1 dual-homed (Leaf1 + Leaf2): `10.10.10.0/31`, `10.10.10.2/31`
+  - Client2 single-homed (Leaf3): `10.20.20.0/31`
+
+## Firewall Rules (Easy to Extend)
+
+The firewall policy is stored in:
+
+- `frr-dc-vxlan-evpn/firewall/iptables.rules.v4`
+
+Current behavior:
+
+- Allows established/related flows
+- Allows Blue and Red segments to go out via outside interface
+- Allows Blue ↔ Red forwarding (for lab validation)
+- NATs client source ranges to outside interface
+
+To extend policy later, edit this file and re-apply:
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 iptables-restore < frr-dc-vxlan-evpn/firewall/iptables.rules.v4
+```
+
+## Deploy
+
+From repository root:
+
+```bash
+containerlab deploy -t frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml
+```
+
+Destroy lab:
+
+```bash
+containerlab destroy -t frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml
+```
+
+## Basic Validation Workflow
+
+1. Verify BGP sessions on spines/leaves
+2. Verify EVPN routes on leaves
+3. Verify client routes are present in service VRFs
+4. Verify firewall learned paths and default-originate behavior
+5. Verify reachability from clients to firewall and to `8.8.8.8`
+
+## Troubleshooting Commands
+
+### containerlab
+
+```bash
+containerlab inspect -t frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml
+containerlab graph -t frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml
+```
+
+### FRR checks
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-spine1 vtysh -c 'show bgp summary'
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp summary'
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp l2vpn evpn summary'
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp vrf blue ipv4 summary'
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 vtysh -c 'show bgp vrf red ipv4 summary'
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 vtysh -c 'show bgp vrf blue ipv4 summary'
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 vtysh -c 'show bgp vrf red ipv4 summary'
+```
+
+### Firewall policy + NAT checks
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 iptables -S
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 iptables -t nat -S
+docker exec -it clab-frr-dc-vxlan-evpn-fw1 iptables -L -n -v
+```
+
+### Connectivity checks
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-client1 ping -c 3 172.16.10.1
+docker exec -it clab-frr-dc-vxlan-evpn-client2 ping -c 3 172.16.20.1
+docker exec -it clab-frr-dc-vxlan-evpn-client1 ping -c 3 8.8.8.8
+docker exec -it clab-frr-dc-vxlan-evpn-client2 ping -c 3 8.8.8.8
+```
+
+### Path debugging
+
+```bash
+docker exec -it clab-frr-dc-vxlan-evpn-client1 traceroute 8.8.8.8
+docker exec -it clab-frr-dc-vxlan-evpn-client2 traceroute 8.8.8.8
+docker exec -it clab-frr-dc-vxlan-evpn-leaf1 ip route
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # FRR DC VXLAN EVPN (containerlab)
 
+> New to EVPN? Start with `Introduction.md` for a beginner walkthrough.
+
 This repository contains a ready-to-use **containerlab** project for a small data-center fabric built with **FRR**:
 
 - 2x Spine routers (FRR)

--- a/frr-dc-vxlan-evpn/configs/client1/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/client1/frr.conf
@@ -1,0 +1,31 @@
+frr version 9.1
+frr defaults datacenter
+hostname client1
+service integrated-vtysh-config
+!
+interface lo
+ ip address 10.10.10.10/32
+!
+interface eth1
+ ip address 10.10.10.0/31
+!
+interface eth2
+ ip address 10.10.10.2/31
+!
+router bgp 65150
+ bgp router-id 10.10.10.10
+ no bgp default ipv4-unicast
+ bgp bestpath as-path multipath-relax
+ maximum-paths 2
+ neighbor 10.10.10.1 remote-as 65101
+ neighbor 10.10.10.3 remote-as 65102
+ address-family ipv4 unicast
+  neighbor 10.10.10.1 activate
+  neighbor 10.10.10.3 activate
+  network 10.10.10.10/32
+ exit-address-family
+!
+ip route 0.0.0.0/0 10.10.10.1
+ip route 0.0.0.0/0 10.10.10.3
+!
+line vty

--- a/frr-dc-vxlan-evpn/configs/client2/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/client2/frr.conf
@@ -1,0 +1,23 @@
+frr version 9.1
+frr defaults datacenter
+hostname client2
+service integrated-vtysh-config
+!
+interface lo
+ ip address 10.20.20.20/32
+!
+interface eth1
+ ip address 10.20.20.0/31
+!
+router bgp 65160
+ bgp router-id 10.20.20.20
+ no bgp default ipv4-unicast
+ neighbor 10.20.20.1 remote-as 65103
+ address-family ipv4 unicast
+  neighbor 10.20.20.1 activate
+  network 10.20.20.20/32
+ exit-address-family
+!
+ip route 0.0.0.0/0 10.20.20.1
+!
+line vty

--- a/frr-dc-vxlan-evpn/configs/edge1/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/edge1/frr.conf
@@ -1,0 +1,21 @@
+frr version 9.1
+frr defaults datacenter
+hostname edge1
+service integrated-vtysh-config
+!
+interface lo
+ ip address 8.8.8.8/32
+!
+interface eth1
+ ip address 172.31.0.0/31
+!
+router bgp 65300
+ bgp router-id 8.8.8.8
+ no bgp default ipv4-unicast
+ neighbor 172.31.0.1 remote-as 65101
+ address-family ipv4 unicast
+  neighbor 172.31.0.1 activate
+  network 8.8.8.8/32
+ exit-address-family
+!
+line vty

--- a/frr-dc-vxlan-evpn/configs/fw1/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/fw1/frr.conf
@@ -1,0 +1,52 @@
+frr version 9.1
+frr defaults datacenter
+hostname fw1
+service integrated-vtysh-config
+!
+vrf blue
+ vni 10001
+!
+vrf red
+ vni 10002
+!
+interface eth1
+ vrf blue
+ ip address 172.16.10.1/31
+!
+interface eth2
+ vrf red
+ ip address 172.16.20.1/31
+!
+interface eth3
+ ip address 172.31.0.5/31
+!
+router bgp 65200
+ bgp router-id 172.31.0.5
+ no bgp default ipv4-unicast
+ neighbor 172.31.0.4 remote-as 65101
+ address-family ipv4 unicast
+  neighbor 172.31.0.4 activate
+  network 172.31.0.5/31
+ exit-address-family
+!
+router bgp 65200 vrf blue
+ no bgp default ipv4-unicast
+ neighbor 172.16.10.0 remote-as 65101
+ address-family ipv4 unicast
+  neighbor 172.16.10.0 activate
+  neighbor 172.16.10.0 default-originate
+  network 172.16.10.0/31
+ exit-address-family
+!
+router bgp 65200 vrf red
+ no bgp default ipv4-unicast
+ neighbor 172.16.20.0 remote-as 65101
+ address-family ipv4 unicast
+  neighbor 172.16.20.0 activate
+  neighbor 172.16.20.0 default-originate
+  network 172.16.20.0/31
+ exit-address-family
+!
+ip route 0.0.0.0/0 172.31.0.4
+!
+line vty

--- a/frr-dc-vxlan-evpn/configs/leaf1/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/leaf1/frr.conf
@@ -1,0 +1,86 @@
+frr version 9.1
+frr defaults datacenter
+hostname leaf1
+service integrated-vtysh-config
+!
+vrf blue
+ vni 10001
+!
+vrf red
+ vni 10002
+!
+interface lo
+ ip address 10.255.1.1/32
+!
+interface eth1
+ ip address 10.0.0.1/31
+!
+interface eth2
+ ip address 10.0.0.3/31
+!
+interface eth3
+ ip address 172.31.0.1/31
+!
+interface eth4
+ vrf blue
+ ip address 172.16.10.0/31
+!
+interface eth5
+ vrf red
+ ip address 172.16.20.0/31
+!
+interface eth6
+ ip address 172.31.0.4/31
+!
+interface eth7
+ vrf blue
+ ip address 10.10.10.1/31
+!
+router bgp 65101
+ bgp router-id 10.255.1.1
+ no bgp default ipv4-unicast
+ neighbor SPINES peer-group
+ neighbor SPINES remote-as external
+ neighbor eth1 interface peer-group SPINES
+ neighbor eth2 interface peer-group SPINES
+ neighbor 172.31.0.0 remote-as 65300
+ neighbor 172.31.0.5 remote-as 65200
+ !
+ address-family ipv4 unicast
+  neighbor SPINES activate
+  neighbor 172.31.0.0 activate
+  neighbor 172.31.0.5 activate
+  network 10.255.1.1/32
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor SPINES activate
+  advertise-all-vni
+  advertise ipv4 unicast
+ exit-address-family
+!
+router bgp 65101 vrf blue
+ no bgp default ipv4-unicast
+ neighbor 172.16.10.1 remote-as 65200
+ neighbor 10.10.10.0 remote-as 65150
+ address-family ipv4 unicast
+  neighbor 172.16.10.1 activate
+  neighbor 10.10.10.0 activate
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+!
+router bgp 65101 vrf red
+ no bgp default ipv4-unicast
+ neighbor 172.16.20.1 remote-as 65200
+ address-family ipv4 unicast
+  neighbor 172.16.20.1 activate
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+!
+line vty

--- a/frr-dc-vxlan-evpn/configs/leaf2/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/leaf2/frr.conf
@@ -1,0 +1,63 @@
+frr version 9.1
+frr defaults datacenter
+hostname leaf2
+service integrated-vtysh-config
+!
+vrf blue
+ vni 10001
+!
+vrf red
+ vni 10002
+!
+interface lo
+ ip address 10.255.1.2/32
+!
+interface eth1
+ ip address 10.0.0.5/31
+!
+interface eth2
+ ip address 10.0.0.7/31
+!
+interface eth3
+ ip address 10.10.10.3/31
+!
+router bgp 65102
+ bgp router-id 10.255.1.2
+ no bgp default ipv4-unicast
+ neighbor SPINES peer-group
+ neighbor SPINES remote-as external
+ neighbor eth1 interface peer-group SPINES
+ neighbor eth2 interface peer-group SPINES
+ !
+ address-family ipv4 unicast
+  neighbor SPINES activate
+  network 10.255.1.2/32
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor SPINES activate
+  advertise-all-vni
+  advertise ipv4 unicast
+ exit-address-family
+!
+router bgp 65102 vrf blue
+ no bgp default ipv4-unicast
+ neighbor 10.10.10.2 remote-as 65150
+ address-family ipv4 unicast
+  neighbor 10.10.10.2 activate
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+!
+router bgp 65102 vrf red
+ no bgp default ipv4-unicast
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+!
+line vty

--- a/frr-dc-vxlan-evpn/configs/leaf3/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/leaf3/frr.conf
@@ -1,0 +1,64 @@
+frr version 9.1
+frr defaults datacenter
+hostname leaf3
+service integrated-vtysh-config
+!
+vrf blue
+ vni 10001
+!
+vrf red
+ vni 10002
+!
+interface lo
+ ip address 10.255.1.3/32
+!
+interface eth1
+ ip address 10.0.0.9/31
+!
+interface eth2
+ ip address 10.0.0.11/31
+!
+interface eth3
+ vrf red
+ ip address 10.20.20.1/31
+!
+router bgp 65103
+ bgp router-id 10.255.1.3
+ no bgp default ipv4-unicast
+ neighbor SPINES peer-group
+ neighbor SPINES remote-as external
+ neighbor eth1 interface peer-group SPINES
+ neighbor eth2 interface peer-group SPINES
+ !
+ address-family ipv4 unicast
+  neighbor SPINES activate
+  network 10.255.1.3/32
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor SPINES activate
+  advertise-all-vni
+  advertise ipv4 unicast
+ exit-address-family
+!
+router bgp 65103 vrf blue
+ no bgp default ipv4-unicast
+ address-family ipv4 unicast
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+!
+router bgp 65103 vrf red
+ no bgp default ipv4-unicast
+ neighbor 10.20.20.0 remote-as 65160
+ address-family ipv4 unicast
+  neighbor 10.20.20.0 activate
+  redistribute connected
+ exit-address-family
+ address-family l2vpn evpn
+  advertise ipv4 unicast
+ exit-address-family
+!
+line vty

--- a/frr-dc-vxlan-evpn/configs/spine1/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/spine1/frr.conf
@@ -1,0 +1,36 @@
+frr version 9.1
+frr defaults datacenter
+hostname spine1
+service integrated-vtysh-config
+!
+interface lo
+ ip address 10.255.0.1/32
+!
+interface eth1
+ ip address 10.0.0.0/31
+!
+interface eth2
+ ip address 10.0.0.4/31
+!
+interface eth3
+ ip address 10.0.0.8/31
+!
+router bgp 65000
+ bgp router-id 10.255.0.1
+ no bgp default ipv4-unicast
+ neighbor LEAFS peer-group
+ neighbor LEAFS remote-as external
+ neighbor eth1 interface peer-group LEAFS
+ neighbor eth2 interface peer-group LEAFS
+ neighbor eth3 interface peer-group LEAFS
+ !
+ address-family ipv4 unicast
+  neighbor LEAFS activate
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor LEAFS activate
+  neighbor LEAFS route-reflector-client
+ exit-address-family
+!
+line vty

--- a/frr-dc-vxlan-evpn/configs/spine2/frr.conf
+++ b/frr-dc-vxlan-evpn/configs/spine2/frr.conf
@@ -1,0 +1,36 @@
+frr version 9.1
+frr defaults datacenter
+hostname spine2
+service integrated-vtysh-config
+!
+interface lo
+ ip address 10.255.0.2/32
+!
+interface eth1
+ ip address 10.0.0.2/31
+!
+interface eth2
+ ip address 10.0.0.6/31
+!
+interface eth3
+ ip address 10.0.0.10/31
+!
+router bgp 65000
+ bgp router-id 10.255.0.2
+ no bgp default ipv4-unicast
+ neighbor LEAFS peer-group
+ neighbor LEAFS remote-as external
+ neighbor eth1 interface peer-group LEAFS
+ neighbor eth2 interface peer-group LEAFS
+ neighbor eth3 interface peer-group LEAFS
+ !
+ address-family ipv4 unicast
+  neighbor LEAFS activate
+ exit-address-family
+ !
+ address-family l2vpn evpn
+  neighbor LEAFS activate
+  neighbor LEAFS route-reflector-client
+ exit-address-family
+!
+line vty

--- a/frr-dc-vxlan-evpn/firewall/iptables.rules.v4
+++ b/frr-dc-vxlan-evpn/firewall/iptables.rules.v4
@@ -1,0 +1,31 @@
+*filter
+:INPUT ACCEPT [0:0]
+:FORWARD DROP [0:0]
+:OUTPUT ACCEPT [0:0]
+
+# Allow established/related
+-A FORWARD -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+
+# Allow Blue VRF client traffic to WAN (eth3)
+-A FORWARD -i eth1 -o eth3 -j ACCEPT
+
+# Allow Red VRF client traffic to WAN (eth3)
+-A FORWARD -i eth2 -o eth3 -j ACCEPT
+
+# Allow Blue <-> Red for lab validation (remove when hardening)
+-A FORWARD -i eth1 -o eth2 -j ACCEPT
+-A FORWARD -i eth2 -o eth1 -j ACCEPT
+
+COMMIT
+
+*nat
+:PREROUTING ACCEPT [0:0]
+:INPUT ACCEPT [0:0]
+:OUTPUT ACCEPT [0:0]
+:POSTROUTING ACCEPT [0:0]
+
+# NAT both VRFs to outside interface
+-A POSTROUTING -s 10.10.10.0/24 -o eth3 -j MASQUERADE
+-A POSTROUTING -s 10.20.20.0/24 -o eth3 -j MASQUERADE
+
+COMMIT

--- a/frr-dc-vxlan-evpn/scripts/setup-firewall.sh
+++ b/frr-dc-vxlan-evpn/scripts/setup-firewall.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ip link add vrf-blue type vrf table 1001 || true
+ip link add vrf-red type vrf table 1002 || true
+ip link set vrf-blue up
+ip link set vrf-red up
+ip link set eth1 master vrf-blue || true
+ip link set eth2 master vrf-red || true
+
+sysctl -w net.ipv4.ip_forward=1 >/dev/null
+
+iptables-restore < /workspace/firewall/iptables.rules.v4
+
+echo "[fw1] firewall + vrfs initialized"

--- a/frr-dc-vxlan-evpn/scripts/setup-leaf-vrfs.sh
+++ b/frr-dc-vxlan-evpn/scripts/setup-leaf-vrfs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NODE_NAME="${1:-leaf}"
+
+ip link add vrf-blue type vrf table 1001 || true
+ip link add vrf-red type vrf table 1002 || true
+ip link set vrf-blue up
+ip link set vrf-red up
+
+# Attach service-facing interfaces when present
+for intf in eth4 eth7; do
+  ip link set "$intf" master vrf-blue 2>/dev/null || true
+done
+for intf in eth5; do
+  ip link set "$intf" master vrf-red 2>/dev/null || true
+done
+
+# ECMP test client links on leaf2/leaf3 should stay in default VRF unless explicitly set above.
+sysctl -w net.ipv4.ip_forward=1 >/dev/null
+
+echo "[$NODE_NAME] VRFs ready"

--- a/frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml
+++ b/frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml
@@ -1,0 +1,66 @@
+name: frr-dc-vxlan-evpn
+
+topology:
+  defaults:
+    kind: linux
+    image: frrouting/frr:v9.1.0
+
+  nodes:
+    spine1:
+      binds:
+        - ../configs/spine1/frr.conf:/etc/frr/frr.conf
+    spine2:
+      binds:
+        - ../configs/spine2/frr.conf:/etc/frr/frr.conf
+
+    leaf1:
+      binds:
+        - ../configs/leaf1/frr.conf:/etc/frr/frr.conf
+      exec:
+        - /bin/bash -c '/workspace/scripts/setup-leaf-vrfs.sh leaf1'
+    leaf2:
+      binds:
+        - ../configs/leaf2/frr.conf:/etc/frr/frr.conf
+      exec:
+        - /bin/bash -c '/workspace/scripts/setup-leaf-vrfs.sh leaf2'
+    leaf3:
+      binds:
+        - ../configs/leaf3/frr.conf:/etc/frr/frr.conf
+      exec:
+        - /bin/bash -c '/workspace/scripts/setup-leaf-vrfs.sh leaf3'
+
+    edge1:
+      binds:
+        - ../configs/edge1/frr.conf:/etc/frr/frr.conf
+
+    fw1:
+      binds:
+        - ../configs/fw1/frr.conf:/etc/frr/frr.conf
+        - ../firewall/iptables.rules.v4:/workspace/firewall/iptables.rules.v4
+      exec:
+        - /bin/bash -c '/workspace/scripts/setup-firewall.sh'
+
+    client1:
+      binds:
+        - ../configs/client1/frr.conf:/etc/frr/frr.conf
+    client2:
+      binds:
+        - ../configs/client2/frr.conf:/etc/frr/frr.conf
+
+  links:
+    - endpoints: ["spine1:eth1", "leaf1:eth1"]
+    - endpoints: ["spine2:eth1", "leaf1:eth2"]
+    - endpoints: ["spine1:eth2", "leaf2:eth1"]
+    - endpoints: ["spine2:eth2", "leaf2:eth2"]
+    - endpoints: ["spine1:eth3", "leaf3:eth1"]
+    - endpoints: ["spine2:eth3", "leaf3:eth2"]
+
+    - endpoints: ["leaf1:eth3", "edge1:eth1"]
+
+    - endpoints: ["leaf1:eth4", "fw1:eth1"] # VRF BLUE transit
+    - endpoints: ["leaf1:eth5", "fw1:eth2"] # VRF RED transit
+    - endpoints: ["leaf1:eth6", "fw1:eth3"] # outside transit
+
+    - endpoints: ["leaf1:eth7", "client1:eth1"]
+    - endpoints: ["leaf2:eth3", "client1:eth2"]
+    - endpoints: ["leaf3:eth3", "client2:eth1"]


### PR DESCRIPTION
### Motivation
- Provide a ready-to-deploy `containerlab` project that demonstrates an FRR-based DC fabric with EVPN overlay and VRF-based service routing.  
- Include a firewall node with editable `iptables` policy that acts as the gateway for multiple VRFs and NATs traffic to a simulated Internet (`8.8.8.8`).  
- Support a dual-homed L3 client for ECMP-style upstream redundancy and a second client in a separate VRF for cross-service validation.  

### Description
- Add a complete topology file at `frr-dc-vxlan-evpn/topology/clab-frr-dc-vxlan-evpn.yml` describing 2 spines, 3 leaves, 1 edge (internet sim), 1 firewall, and 2 clients with all links.  
- Add FRR configuration files for all nodes under `frr-dc-vxlan-evpn/configs/` implementing underlay eBGP (spines/leaves), EVPN overlay, VRF service BGP, the `8.8.8.8/32` internet advertisement, and client BGP for ECMP (`client1` uses `maximum-paths 2`).  
- Add firewall automation and an externalized policy file: `frr-dc-vxlan-evpn/scripts/setup-firewall.sh` bootstraps VRFs and applies `frr-dc-vxlan-evpn/firewall/iptables.rules.v4` which contains baseline forwarding + NAT rules and is easy to edit for future policy changes.  
- Add `frr-dc-vxlan-evpn/scripts/setup-leaf-vrfs.sh` to create/attach VRFs on leaf nodes, and update top-level `README.md` with deployment, validation, and troubleshooting commands.  

### Testing
- Ran shell syntax checks for bootstrap scripts with `bash -n frr-dc-vxlan-evpn/scripts/setup-leaf-vrfs.sh && bash -n frr-dc-vxlan-evpn/scripts/setup-firewall.sh`, which passed.  
- Attempted YAML validation using a Python `yaml.safe_load` check, but it failed because the environment is missing the `PyYAML` package (`ModuleNotFoundError: No module named 'yaml'`).  
- All scripts were made executable and basic file contents were inspected to verify expected configuration and topology structure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d9b9179c4832493383efe68ef50d6)