### PR TITLE
Add NX-OS VXLAN EVPN automation framework (Jinja2 generator, Nornir deploy, pyATS tests, OpenWebUI helper)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,105 @@
-# codex_ai
+# Cisco NX-OS VXLAN EVPN Fabric Automation (Nornir + scrapli + pyATS + OpenWebUI)
+
+This repository provides an automated workflow for a Cisco NX-OS EVPN fabric with:
+
+- Spine / Leaf / Border-Leaf roles
+- vPC on leaf pairs
+- Border Gateway (DCI) interconnect on border-leaf nodes
+- Unnumbered underlay links
+- OSPF underlay
+- BGP EVPN overlay
+- Dynamic subnet-based BGP neighbor onboarding (`bgp listen range`) to keep leaf configs minimal
+
+## Project structure
+
+```text
+.
+├── automation/
+│   └── nornir_deploy.py            # Deploy configs to devices with Nornir + scrapli
+├── data/
+│   └── fabric.json                 # Source-of-truth topology and policy data
+├── generated/                      # Rendered NX-OS configs (created by script)
+├── inventory/
+│   ├── defaults.yaml               # Credentials + transport settings
+│   ├── groups.yaml                 # Group metadata (spine/leaf/border_leaf)
+│   └── hosts.yaml                  # Device inventory
+├── openwebui/
+│   └── nxos_fabric_assistant.py    # LLM integration against OpenWebUI-compatible endpoint
+├── pyats/
+│   ├── jobs/
+│   │   └── vxlan_job.py            # pyATS job file
+│   ├── tests/
+│   │   └── test_vxlan_evpn.py      # Validation suite
+│   └── testbed_example.yaml        # Example testbed definition
+├── scripts/
+│   └── generate_configs.py         # JSON + Jinja generator
+├── templates/
+│   └── nxos_vxlan_evpn.j2          # NX-OS config template
+└── requirements.txt
+```
+
+## Install
+
+```bash
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## 1) Generate configs (Jinja + JSON)
+
+```bash
+python3 scripts/generate_configs.py
+```
+
+The generated files are written into `generated/<hostname>.cfg`.
+
+## 2) Deploy via Nornir + scrapli
+
+Update credentials in `inventory/defaults.yaml`, then run:
+
+```bash
+python3 automation/nornir_deploy.py
+```
+
+Post-deploy, each host is checked with:
+
+- `show bgp l2vpn evpn summary`
+
+## 3) Validate with pyATS
+
+Update `pyats/testbed_example.yaml` with real device details, then run:
+
+```bash
+easypy pyats/jobs/vxlan_job.py --testbed-file pyats/testbed_example.yaml
+```
+
+Current validations include:
+
+- OSPF adjacency checks
+- EVPN BGP summary checks
+- NVE peer checks (non-spine devices)
+
+## 4) LLM integration (OpenWebUI)
+
+Set environment variables and run the helper:
+
+```bash
+export OPENWEBUI_BASE_URL="http://<openwebui-host>:3000"
+export OPENWEBUI_API_KEY="<token-if-needed>"
+python3 openwebui/nxos_fabric_assistant.py
+```
+
+This sends the `data/fabric.json` payload to your OpenWebUI OpenAI-compatible endpoint and returns deployment guidance/checklists.
+
+## Notes on dynamic BGP neighbors
+
+To minimize repetitive leaf configuration, template logic uses `bgp listen range` with a subnet (not specific IP neighbors) for EVPN peer onboarding.
+
+- Spines listen for leaf loopbacks in a fabric subnet.
+- Leafs listen for spine loopbacks using the loopback pool subnet.
+
+Adjust listen ranges in `data/fabric.json`:
+
+- `fabric.bgp_listen_subnet`
+- `fabric.loopback_pool`

--- a/automation/nornir_deploy.py
+++ b/automation/nornir_deploy.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Deploy rendered configs to NX-OS fabric using Nornir + scrapli."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from nornir import InitNornir
+from nornir.core.task import Task, Result
+from nornir_scrapli.tasks import send_config, send_command
+
+ROOT = Path(__file__).resolve().parents[1]
+GENERATED_DIR = ROOT / "generated"
+
+
+def push_device_config(task: Task) -> Result:
+    cfg_file = GENERATED_DIR / f"{task.host.name}.cfg"
+    if not cfg_file.exists():
+        return Result(
+            host=task.host,
+            failed=True,
+            changed=False,
+            result=f"Missing generated config for {task.host.name}: {cfg_file}",
+        )
+
+    config_lines = [line for line in cfg_file.read_text(encoding="utf-8").splitlines() if line.strip()]
+    task.run(task=send_config, configs=config_lines)
+    check = task.run(task=send_command, command="show bgp l2vpn evpn summary", name="post_check")
+    return Result(host=task.host, changed=True, result=check.result)
+
+
+def main() -> None:
+    nr = InitNornir(
+        runner={"plugin": "threaded", "options": {"num_workers": 10}},
+        inventory={
+            "plugin": "SimpleInventory",
+            "options": {
+                "host_file": str(ROOT / "inventory" / "hosts.yaml"),
+                "group_file": str(ROOT / "inventory" / "groups.yaml"),
+                "defaults_file": str(ROOT / "inventory" / "defaults.yaml"),
+            },
+        },
+    )
+
+    results = nr.run(task=push_device_config)
+    for host, output in results.items():
+        state = "FAILED" if output.failed else "OK"
+        print(f"{host}: {state}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/fabric.json
+++ b/data/fabric.json
@@ -1,0 +1,134 @@
+{
+  "fabric": {
+    "name": "dc1-fabric",
+    "ospf_process": 100,
+    "overlay_asn": 65000,
+    "underlay_area": "0.0.0.0",
+    "loopback_pool": "10.255.0.0/24",
+    "bgp_listen_subnet": "10.255.0.0/24",
+    "vlan_to_vni": [
+      {"vlan": 10, "name": "WEB", "vni": 10010, "svi": "10.10.10.1/24", "vrf": "TENANT_A"},
+      {"vlan": 20, "name": "APP", "vni": 10020, "svi": "10.10.20.1/24", "vrf": "TENANT_A"},
+      {"vlan": 30, "name": "DB", "vni": 10030, "svi": "10.10.30.1/24", "vrf": "TENANT_A"}
+    ],
+    "vrfs": [
+      {"name": "TENANT_A", "vni": 50000, "rt": "65000:50000", "rd": "auto"}
+    ]
+  },
+  "devices": [
+    {
+      "name": "spine1",
+      "role": "spine",
+      "mgmt_ip": "192.0.2.11",
+      "loopback0": "10.255.0.11/32",
+      "router_id": "10.255.0.11",
+      "asn": 65000,
+      "interfaces": [
+        {"name": "Ethernet1/1", "peer": "leaf1", "peer_intf": "Ethernet1/49", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/2", "peer": "leaf2", "peer_intf": "Ethernet1/49", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/3", "peer": "bleaf1", "peer_intf": "Ethernet1/49", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/4", "peer": "bleaf2", "peer_intf": "Ethernet1/49", "ospf_network_type": "point-to-point"}
+      ]
+    },
+    {
+      "name": "spine2",
+      "role": "spine",
+      "mgmt_ip": "192.0.2.12",
+      "loopback0": "10.255.0.12/32",
+      "router_id": "10.255.0.12",
+      "asn": 65000,
+      "interfaces": [
+        {"name": "Ethernet1/1", "peer": "leaf1", "peer_intf": "Ethernet1/50", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/2", "peer": "leaf2", "peer_intf": "Ethernet1/50", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/3", "peer": "bleaf1", "peer_intf": "Ethernet1/50", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/4", "peer": "bleaf2", "peer_intf": "Ethernet1/50", "ospf_network_type": "point-to-point"}
+      ]
+    },
+    {
+      "name": "leaf1",
+      "role": "leaf",
+      "mgmt_ip": "192.0.2.21",
+      "loopback0": "10.255.0.21/32",
+      "router_id": "10.255.0.21",
+      "anycast_gateway_mac": "0000.1111.2222",
+      "asn": 65101,
+      "vpc": {
+        "domain": 10,
+        "peer_keepalive_src": "192.0.2.21",
+        "peer_keepalive_dst": "192.0.2.22",
+        "peer_link_po": 10,
+        "peer_link_members": ["Ethernet1/47"],
+        "member_port_channels": [
+          {"id": 101, "description": "to-esxi-cluster", "members": ["Ethernet1/10", "Ethernet1/11"], "vlan": "10,20,30"}
+        ]
+      },
+      "interfaces": [
+        {"name": "Ethernet1/49", "peer": "spine1", "peer_intf": "Ethernet1/1", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/50", "peer": "spine2", "peer_intf": "Ethernet1/1", "ospf_network_type": "point-to-point"}
+      ]
+    },
+    {
+      "name": "leaf2",
+      "role": "leaf",
+      "mgmt_ip": "192.0.2.22",
+      "loopback0": "10.255.0.22/32",
+      "router_id": "10.255.0.22",
+      "anycast_gateway_mac": "0000.1111.2222",
+      "asn": 65101,
+      "vpc": {
+        "domain": 10,
+        "peer_keepalive_src": "192.0.2.22",
+        "peer_keepalive_dst": "192.0.2.21",
+        "peer_link_po": 10,
+        "peer_link_members": ["Ethernet1/47"],
+        "member_port_channels": [
+          {"id": 101, "description": "to-esxi-cluster", "members": ["Ethernet1/10", "Ethernet1/11"], "vlan": "10,20,30"}
+        ]
+      },
+      "interfaces": [
+        {"name": "Ethernet1/49", "peer": "spine1", "peer_intf": "Ethernet1/2", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/50", "peer": "spine2", "peer_intf": "Ethernet1/2", "ospf_network_type": "point-to-point"}
+      ]
+    },
+    {
+      "name": "bleaf1",
+      "role": "border_leaf",
+      "mgmt_ip": "192.0.2.31",
+      "loopback0": "10.255.0.31/32",
+      "router_id": "10.255.0.31",
+      "asn": 65131,
+      "border_gateway": {
+        "dci_port_channel": 131,
+        "dci_members": ["Ethernet1/55", "Ethernet1/56"],
+        "peer": "bleaf2",
+        "peer_ip": "172.16.100.2/31",
+        "local_ip": "172.16.100.1/31",
+        "peer_as": 65200
+      },
+      "interfaces": [
+        {"name": "Ethernet1/49", "peer": "spine1", "peer_intf": "Ethernet1/3", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/50", "peer": "spine2", "peer_intf": "Ethernet1/3", "ospf_network_type": "point-to-point"}
+      ]
+    },
+    {
+      "name": "bleaf2",
+      "role": "border_leaf",
+      "mgmt_ip": "192.0.2.32",
+      "loopback0": "10.255.0.32/32",
+      "router_id": "10.255.0.32",
+      "asn": 65132,
+      "border_gateway": {
+        "dci_port_channel": 132,
+        "dci_members": ["Ethernet1/55", "Ethernet1/56"],
+        "peer": "bleaf1",
+        "peer_ip": "172.16.100.1/31",
+        "local_ip": "172.16.100.2/31",
+        "peer_as": 65200
+      },
+      "interfaces": [
+        {"name": "Ethernet1/49", "peer": "spine1", "peer_intf": "Ethernet1/4", "ospf_network_type": "point-to-point"},
+        {"name": "Ethernet1/50", "peer": "spine2", "peer_intf": "Ethernet1/4", "ospf_network_type": "point-to-point"}
+      ]
+    }
+  ]
+}

--- a/inventory/defaults.yaml
+++ b/inventory/defaults.yaml
@@ -1,0 +1,7 @@
+username: admin
+password: admin
+connection_options:
+  scrapli:
+    extras:
+      auth_strict_key: false
+      transport: system

--- a/inventory/groups.yaml
+++ b/inventory/groups.yaml
@@ -1,0 +1,9 @@
+spines:
+  data:
+    role: spine
+leafs:
+  data:
+    role: leaf
+border_leafs:
+  data:
+    role: border_leaf

--- a/inventory/hosts.yaml
+++ b/inventory/hosts.yaml
@@ -1,0 +1,24 @@
+spine1:
+  hostname: 192.0.2.11
+  platform: cisco_nxos
+  groups: [spines]
+spine2:
+  hostname: 192.0.2.12
+  platform: cisco_nxos
+  groups: [spines]
+leaf1:
+  hostname: 192.0.2.21
+  platform: cisco_nxos
+  groups: [leafs]
+leaf2:
+  hostname: 192.0.2.22
+  platform: cisco_nxos
+  groups: [leafs]
+bleaf1:
+  hostname: 192.0.2.31
+  platform: cisco_nxos
+  groups: [border_leafs]
+bleaf2:
+  hostname: 192.0.2.32
+  platform: cisco_nxos
+  groups: [border_leafs]

--- a/openwebui/nxos_fabric_assistant.py
+++ b/openwebui/nxos_fabric_assistant.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""OpenWebUI/OpenAI-compatible helper for NX-OS EVPN fabric generation and checks."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import requests
+
+ROOT = Path(__file__).resolve().parents[1]
+FABRIC_FILE = ROOT / "data" / "fabric.json"
+
+SYSTEM_PROMPT = """
+You are a Cisco NX-OS EVPN automation copilot.
+- Use unnumbered interfaces for underlay.
+- Underlay protocol is OSPF.
+- Overlay protocol is BGP EVPN.
+- Include Spine/Leaf/Border-Leaf, vPC pairs, and DCI border gateways.
+- Prefer dynamic/subnet-based BGP neighbors with listen ranges where possible.
+""".strip()
+
+
+def call_openwebui(user_prompt: str, model: str = "gpt-4o-mini") -> str:
+    base_url = os.getenv("OPENWEBUI_BASE_URL", "http://localhost:3000")
+    api_key = os.getenv("OPENWEBUI_API_KEY", "")
+    endpoint = f"{base_url.rstrip('/')}/api/chat/completions"
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    payload = {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ],
+        "temperature": 0.1,
+    }
+
+    response = requests.post(endpoint, headers=headers, data=json.dumps(payload), timeout=120)
+    response.raise_for_status()
+    data = response.json()
+    return data["choices"][0]["message"]["content"]
+
+
+def main() -> None:
+    fabric = FABRIC_FILE.read_text(encoding="utf-8")
+    user_prompt = (
+        "Generate deployment notes and a change-checklist for this Cisco NX-OS fabric JSON:\n"
+        f"{fabric}"
+    )
+    print(call_openwebui(user_prompt=user_prompt))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyats/jobs/vxlan_job.py
+++ b/pyats/jobs/vxlan_job.py
@@ -1,0 +1,7 @@
+"""pyATS job file for NX-OS VXLAN EVPN validations."""
+
+from pyats.easypy import run
+
+
+def main(runtime):
+    run(testscript="pyats/tests/test_vxlan_evpn.py", testbed=runtime.testbed)

--- a/pyats/testbed_example.yaml
+++ b/pyats/testbed_example.yaml
@@ -1,0 +1,29 @@
+testbed:
+  name: nxos-fabric
+
+devices:
+  spine1:
+    alias: spine1
+    os: nxos
+    type: switch
+    connections:
+      cli:
+        protocol: ssh
+        ip: 192.0.2.11
+    credentials:
+      default:
+        username: admin
+        password: admin
+
+  leaf1:
+    alias: leaf1
+    os: nxos
+    type: switch
+    connections:
+      cli:
+        protocol: ssh
+        ip: 192.0.2.21
+    credentials:
+      default:
+        username: admin
+        password: admin

--- a/pyats/tests/test_vxlan_evpn.py
+++ b/pyats/tests/test_vxlan_evpn.py
@@ -1,0 +1,52 @@
+"""pyATS/Genie validation for NX-OS VXLAN EVPN fabric."""
+
+from __future__ import annotations
+
+from pyats import aetest
+
+
+class CommonSetup(aetest.CommonSetup):
+    @aetest.subsection
+    def connect_to_devices(self, testbed):
+        testbed.connect(log_stdout=False)
+        self.parent.parameters["testbed"] = testbed
+
+
+class ValidateUnderlay(aetest.Testcase):
+    @aetest.test
+    def ospf_neighbors_full(self, testbed):
+        for device in testbed.devices.values():
+            parsed = device.parse("show ip ospf neighbors")
+            self.assertTrue(
+                parsed.get("interfaces"),
+                f"No OSPF neighbors found on {device.name}",
+            )
+
+
+class ValidateOverlay(aetest.Testcase):
+    @aetest.test
+    def evpn_bgp_established(self, testbed):
+        for device in testbed.devices.values():
+            parsed = device.parse("show bgp l2vpn evpn summary")
+            vrf_data = parsed.get("vrf", {})
+            self.assertTrue(vrf_data, f"No EVPN BGP data on {device.name}")
+
+
+class ValidateNve(aetest.Testcase):
+    @aetest.test
+    def nve_peers_up(self, testbed):
+        for device in testbed.devices.values():
+            if "spine" in device.alias:
+                continue
+            parsed = device.parse("show nve peers")
+            self.assertTrue(parsed.get("nve_peers"), f"No NVE peers on {device.name}")
+
+
+class CommonCleanup(aetest.CommonCleanup):
+    @aetest.subsection
+    def disconnect(self, testbed):
+        testbed.disconnect()
+
+
+if __name__ == "__main__":
+    aetest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,9 @@
+nornir==3.5.0
+nornir-utils==0.2.0
+nornir-scrapli==2025.1.30
+scrapli==2025.1.30
+jinja2==3.1.4
+pyyaml==6.0.2
+pyats==25.2
+genie==25.2
+requests==2.32.3

--- a/scripts/generate_configs.py
+++ b/scripts/generate_configs.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Generate Cisco NX-OS VXLAN EVPN configs from JSON + Jinja2."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_FILE = ROOT / "data" / "fabric.json"
+TEMPLATE_DIR = ROOT / "templates"
+TEMPLATE_FILE = "nxos_vxlan_evpn.j2"
+OUTPUT_DIR = ROOT / "generated"
+
+
+def load_fabric_data(path: Path) -> dict:
+    with path.open("r", encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def render_configs(payload: dict) -> dict[str, str]:
+    env = Environment(
+        loader=FileSystemLoader(str(TEMPLATE_DIR)),
+        trim_blocks=True,
+        lstrip_blocks=True,
+        undefined=StrictUndefined,
+    )
+    template = env.get_template(TEMPLATE_FILE)
+
+    rendered: dict[str, str] = {}
+    for device in payload["devices"]:
+        config = template.render(device=device, fabric=payload["fabric"])
+        rendered[device["name"]] = config.rstrip() + "\n"
+    return rendered
+
+
+def write_configs(configs: dict[str, str], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for device, config in configs.items():
+        outfile = output_dir / f"{device}.cfg"
+        outfile.write_text(config, encoding="utf-8")
+
+
+def main() -> None:
+    payload = load_fabric_data(DATA_FILE)
+    configs = render_configs(payload)
+    write_configs(configs, OUTPUT_DIR)
+    print(f"Rendered {len(configs)} configurations into {OUTPUT_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/templates/nxos_vxlan_evpn.j2
+++ b/templates/nxos_vxlan_evpn.j2
@@ -1,0 +1,136 @@
+! Generated for {{ device.name }} ({{ device.role }})
+hostname {{ device.name }}
+feature ospf
+feature bgp
+feature nv overlay
+feature vn-segment-vlan-based
+feature interface-vlan
+{% if device.vpc is defined %}
+feature vpc
+{% endif %}
+
+interface loopback0
+  ip address {{ device.loopback0 }}
+  ip router ospf {{ fabric.ospf_process }} area {{ fabric.underlay_area }}
+
+router ospf {{ fabric.ospf_process }}
+  router-id {{ device.router_id }}
+
+{% for link in device.interfaces %}
+interface {{ link.name }}
+  no switchport
+  medium p2p
+  ip unnumbered loopback0
+  ip ospf network {{ link.ospf_network_type }}
+  ip router ospf {{ fabric.ospf_process }} area {{ fabric.underlay_area }}
+  no shutdown
+{% endfor %}
+
+{% if device.vpc is defined %}
+vpc domain {{ device.vpc.domain }}
+  peer-switch
+  peer-keepalive destination {{ device.vpc.peer_keepalive_dst }} source {{ device.vpc.peer_keepalive_src }} vrf management
+
+interface port-channel{{ device.vpc.peer_link_po }}
+  switchport
+  switchport mode trunk
+  spanning-tree port type network
+  vpc peer-link
+
+{% for member in device.vpc.peer_link_members %}
+interface {{ member }}
+  channel-group {{ device.vpc.peer_link_po }} mode active
+{% endfor %}
+
+{% for po in device.vpc.member_port_channels %}
+interface port-channel{{ po.id }}
+  description {{ po.description }}
+  switchport
+  switchport mode trunk
+  switchport trunk allowed vlan {{ po.vlan }}
+  vpc {{ po.id }}
+
+{% for m in po.members %}
+interface {{ m }}
+  channel-group {{ po.id }} mode active
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+{% if device.role != 'spine' %}
+interface nve1
+  no shutdown
+  host-reachability protocol bgp
+  source-interface loopback0
+{% for vlan in fabric.vlan_to_vni %}
+  member vni {{ vlan.vni }}
+    ingress-replication protocol bgp
+{% endfor %}
+
+fabric forwarding anycast-gateway-mac {{ device.anycast_gateway_mac | default('0000.1111.2222') }}
+
+{% for vrf in fabric.vrfs %}
+vrf context {{ vrf.name }}
+  vni {{ vrf.vni }}
+  rd {{ vrf.rd }}
+  address-family ipv4 unicast
+    route-target both {{ vrf.rt }}
+{% endfor %}
+
+{% for vlan in fabric.vlan_to_vni %}
+vlan {{ vlan.vlan }}
+  name {{ vlan.name }}
+  vn-segment {{ vlan.vni }}
+
+interface Vlan{{ vlan.vlan }}
+  no shutdown
+  vrf member {{ vlan.vrf }}
+  ip address {{ vlan.svi }}
+  fabric forwarding mode anycast-gateway
+{% endfor %}
+{% endif %}
+
+router bgp {{ device.asn }}
+  router-id {{ device.router_id }}
+  address-family l2vpn evpn
+
+{% if device.role == 'spine' %}
+  template peer LEAF-EVPN
+    remote-as external
+    update-source loopback0
+    address-family l2vpn evpn
+      send-community
+      send-community extended
+      route-reflector-client
+
+  bgp listen range {{ fabric.bgp_listen_subnet }} peer-group LEAF-EVPN
+{% else %}
+  template peer SPINE-EVPN
+    remote-as {{ fabric.overlay_asn }}
+    update-source loopback0
+    address-family l2vpn evpn
+      send-community
+      send-community extended
+
+  bgp listen range {{ fabric.loopback_pool }} peer-group SPINE-EVPN
+{% endif %}
+
+{% if device.role == 'border_leaf' and device.border_gateway is defined %}
+interface port-channel{{ device.border_gateway.dci_port_channel }}
+  description DCI-to-remote-border
+  no switchport
+  ip address {{ device.border_gateway.local_ip }}
+  no shutdown
+
+{% for member in device.border_gateway.dci_members %}
+interface {{ member }}
+  channel-group {{ device.border_gateway.dci_port_channel }} mode active
+{% endfor %}
+
+router bgp {{ device.asn }}
+  neighbor {{ device.border_gateway.peer_ip.split('/')[0] }}
+    remote-as {{ device.border_gateway.peer_as }}
+    address-family l2vpn evpn
+      send-community
+      send-community extended
+{% endif %}


### PR DESCRIPTION
### Motivation
- Provide a reproducible automation workflow to generate, deploy, and validate Cisco NX-OS VXLAN EVPN fabrics (Spine/Leaf/Border‑Leaf with vPC and DCI). 
- Use unnumbered underlay links with OSPF and a BGP EVPN overlay while minimizing repetitive leaf config by using subnet-based dynamic neighbors (`bgp listen range`).
- Expose the fabric model to an LLM endpoint for deployment notes and change-checklists to accelerate operational tasks.

### Description
- Scaffold a full project layout and add a JSON source-of-truth at `data/fabric.json` plus a Jinja2 template `templates/nxos_vxlan_evpn.j2` and renderer `scripts/generate_configs.py` to produce per-device NX‑OS configs. 
- Add Nornir + scrapli deployment workflow in `automation/nornir_deploy.py` with SimpleInventory files under `inventory/` and a post-deploy EVPN health check. 
- Add a pyATS validation suite and job/testbed examples (`pyats/tests/test_vxlan_evpn.py`, `pyats/jobs/vxlan_job.py`, `pyats/testbed_example.yaml`) to validate OSPF adjacencies, EVPN BGP, and NVE peers. 
- Add an OpenWebUI/OpenAI-compatible helper `openwebui/nxos_fabric_assistant.py`, a pinned `requirements.txt`, and document usage in `README.md`.

### Testing
- Ran `python3 -m compileall automation scripts openwebui pyats/tests pyats/jobs` which succeeded. 
- Ran `python3 scripts/generate_configs.py` which failed in this environment due to the missing `jinja2` package. 
- Attempted `pip install jinja2 pyyaml requests` which failed in this runtime because package index/proxy access is blocked, so end-to-end generation/deploy/pyATS execution against devices could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb34b922888324b5e379300662dc9e)